### PR TITLE
[gitlab] add identifier field

### DIFF
--- a/core/jreleaser-model/src/main/java/org/jreleaser/model/Gitlab.java
+++ b/core/jreleaser-model/src/main/java/org/jreleaser/model/Gitlab.java
@@ -17,6 +17,10 @@
  */
 package org.jreleaser.model;
 
+import java.util.Map;
+
+import static org.jreleaser.util.Constants.KEY_IDENTIFIER;
+
 /**
  * @author Andres Almiray
  * @since 0.1.0
@@ -36,12 +40,38 @@ public class Gitlab extends GitService {
         setIssueTrackerUrlFormat("https://{{repoHost}}/{{repoOwner}}/{{repoName}}/-/issues");
     }
 
+    private String identifier;
+
     void setAll(Gitlab service) {
         super.setAll(service);
+        this.identifier = service.identifier;
     }
 
     @Override
     public String getReverseRepoHost() {
         return "com.gitlab";
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    @Override
+    public Map<String, Object> asMap(boolean full) {
+        Map<String, Object> map = super.asMap(full);
+        map.put("identifier", identifier);
+        return map;
+    }
+
+    @Override
+    public Map<String, Object> props(JReleaserModel model) {
+        Map<String, Object> props = super.props(model);
+        props.put(KEY_IDENTIFIER, identifier);
+
+        return props;
     }
 }

--- a/core/jreleaser-utils/src/main/java/org/jreleaser/util/Constants.java
+++ b/core/jreleaser-utils/src/main/java/org/jreleaser/util/Constants.java
@@ -70,6 +70,7 @@ public interface Constants {
     String KEY_REPO_HOST = "repoHost";
     String KEY_REPO_OWNER = "repoOwner";
     String KEY_REPO_NAME = "repoName";
+    String KEY_IDENTIFIER = "identifier";
     String KEY_REPO_BRANCH = "repoBranch";
     String KEY_TAG_NAME = "tagName";
     String KEY_RELEASE_NAME = "releaseName";

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/dsl/Gitlab.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/dsl/Gitlab.groovy
@@ -18,6 +18,7 @@
 package org.jreleaser.gradle.plugin.dsl
 
 import groovy.transform.CompileStatic
+import org.gradle.api.provider.Property
 
 /**
  *
@@ -26,4 +27,6 @@ import groovy.transform.CompileStatic
  */
 @CompileStatic
 interface Gitlab extends GitService {
+
+    Property<String> getIdentifier()
 }

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/GitlabImpl.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/GitlabImpl.groovy
@@ -36,6 +36,7 @@ class GitlabImpl extends AbstractGitService implements Gitlab {
     final ChangelogImpl changelog
     final MilestoneImpl milestone
     final CommitAuthorImpl commitAuthor
+    final Property<String> identifier
 
     @Inject
     GitlabImpl(ObjectFactory objects) {
@@ -44,6 +45,8 @@ class GitlabImpl extends AbstractGitService implements Gitlab {
         changelog = objects.newInstance(ChangelogImpl, objects)
         milestone = objects.newInstance(MilestoneImpl, objects)
         commitAuthor = objects.newInstance(CommitAuthorImpl, objects)
+
+        identifier = objects.property(String).convention(Providers.notDefined())
     }
 
     @Override
@@ -61,6 +64,7 @@ class GitlabImpl extends AbstractGitService implements Gitlab {
         if (changelog.isSet()) service.changelog = changelog.toModel()
         if (milestone.isSet()) service.milestone = milestone.toModel()
         if (commitAuthor.isSet()) service.commitAuthor = commitAuthor.toModel()
+        if (identifier.present) service.identifier = identifier.get()
         service
     }
 }

--- a/plugins/jreleaser-maven-plugin/src/main/java/org/jreleaser/maven/plugin/Gitlab.java
+++ b/plugins/jreleaser-maven-plugin/src/main/java/org/jreleaser/maven/plugin/Gitlab.java
@@ -33,7 +33,18 @@ public class Gitlab extends GitService {
         setIssueTrackerUrlFormat("https://{{repoHost}}/{{repoOwner}}/{{repoName}}/-/issues");
     }
 
+    private String identifier;
+
     void setAll(Gitlab service) {
         super.setAll(service);
+        this.identifier = service.identifier;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
     }
 }

--- a/plugins/jreleaser-maven-plugin/src/main/java/org/jreleaser/maven/plugin/internal/JReleaserModelConverter.java
+++ b/plugins/jreleaser-maven-plugin/src/main/java/org/jreleaser/maven/plugin/internal/JReleaserModelConverter.java
@@ -166,6 +166,7 @@ public final class JReleaserModelConverter {
     private static org.jreleaser.model.Gitlab convertGitlab(Gitlab gitlab) {
         if (null == gitlab) return null;
         org.jreleaser.model.Gitlab g = new org.jreleaser.model.Gitlab();
+        g.setIdentifier(gitlab.getIdentifier());
         convertGitService(gitlab, g);
         return g;
     }

--- a/sdks/gitlab-java-sdk/src/main/java/org/jreleaser/sdk/gitlab/api/GitlabAPI.java
+++ b/sdks/gitlab-java-sdk/src/main/java/org/jreleaser/sdk/gitlab/api/GitlabAPI.java
@@ -34,6 +34,10 @@ public interface GitlabAPI {
     @RequestLine("GET /user")
     User getCurrentUser();
 
+    @RequestLine("GET /projects/{projectId}")
+    @Headers("Content-Type: application/json")
+    Project getProject(@Param("projectId") String projectId);
+
     @RequestLine("GET /users/{userId}/projects")
     List<Project> getProject(@Param("userId") Integer userId, @QueryMap Map<String, Object> queryMap);
 


### PR DESCRIPTION
This PR adds the possibility to define the GitLab-specific project IDs. This closes #166.

The mentioned idea that GitLab returns multiple results and JReleaser picks the wrong one is not valid. I discovered that the query returns one result item and prefers a project in the personal space that has the same name, aka a fork. Only if the name is not an exact match, the query returns multiple results. Anyhow, the proposed solution should provide a remedy to that issue. 

I implemented as proposed in the issue. But I think this PR could do better. The SDK GitLab class uses the Model class and spreads the parameter to the submethods. With `identifier this grows even further. If the methods would directly accept git model class, `getProject` could compare the desired path of owner and name if an identifier is not present. That would allow providing a meaningful warning.