### PR TITLE
[maven] Using element name to set Distribution name. Fixes #228

### DIFF
--- a/plugins/jreleaser-maven-plugin/src/main/java/org/jreleaser/maven/plugin/Jreleaser.java
+++ b/plugins/jreleaser-maven-plugin/src/main/java/org/jreleaser/maven/plugin/Jreleaser.java
@@ -17,9 +17,8 @@
  */
 package org.jreleaser.maven.plugin;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * @author Andres Almiray
@@ -36,7 +35,7 @@ public class Jreleaser {
     private final Checksum checksum = new Checksum();
     private final Signing signing = new Signing();
     private final Files files = new Files();
-    private final List<Distribution> distributions = new ArrayList<>();
+    private final Map<String, Distribution> distributions = new LinkedHashMap<>();
 
     public Environment getEnvironment() {
         return environment;
@@ -118,12 +117,12 @@ public class Jreleaser {
         this.files.setAll(files);
     }
 
-    public List<Distribution> getDistributions() {
+    public Map<String, Distribution> getDistributions() {
         return distributions;
     }
 
-    public void setDistributions(Collection<Distribution> distributions) {
+    public void setDistributions(Map<String, Distribution> distributions) {
         this.distributions.clear();
-        this.distributions.addAll(distributions);
+        this.distributions.putAll(distributions);
     }
 }

--- a/plugins/jreleaser-maven-plugin/src/main/java/org/jreleaser/maven/plugin/internal/JReleaserModelConverter.java
+++ b/plugins/jreleaser-maven-plugin/src/main/java/org/jreleaser/maven/plugin/internal/JReleaserModelConverter.java
@@ -629,10 +629,11 @@ public final class JReleaserModelConverter {
         return s;
     }
 
-    private static Map<String, org.jreleaser.model.Distribution> convertDistributions(List<Distribution> distributions) {
+    private static Map<String, org.jreleaser.model.Distribution> convertDistributions(Map<String, Distribution> distributions) {
         Map<String, org.jreleaser.model.Distribution> ds = new LinkedHashMap<>();
-        for (Distribution distribution : distributions) {
-            ds.put(distribution.getName(), convertDistribution(distribution));
+        for (Map.Entry<String,Distribution> e : distributions.entrySet()) {
+            e.getValue().setName(e.getKey());
+            ds.put(e.getKey(), convertDistribution(e.getValue()));
         }
         return ds;
     }


### PR DESCRIPTION
Fixes #228

When configuring the Maven plugin, Distribution name is not taken from the XML element name.

