### PR TITLE
Instantiate GitHub with apiEndpoint otherwise it will not work for github enterprise

### DIFF
--- a/sdks/github-java-sdk/src/main/java/org/jreleaser/sdk/github/GithubReleaser.java
+++ b/sdks/github-java-sdk/src/main/java/org/jreleaser/sdk/github/GithubReleaser.java
@@ -64,6 +64,7 @@ public class GithubReleaser extends AbstractReleaser {
             String changelog = context.getChangelog();
 
             Github api = new Github(context.getLogger(),
+                github.getApiEndpoint(),
                 github.getResolvedToken(),
                 github.getConnectTimeout(),
                 github.getReadTimeout());


### PR DESCRIPTION
Fixes #403

### Context
Resolve this issue https://github.com/jreleaser/jreleaser/issues/403

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
