### PR TITLE
fix: Category titles should use one instead of multiple spaces.

### DIFF
--- a/core/jreleaser-model/src/main/resources/META-INF/jreleaser/changelog/preset-conventional-commits.yml
+++ b/core/jreleaser-model/src/main/resources/META-INF/jreleaser/changelog/preset-conventional-commits.yml
@@ -63,7 +63,7 @@ categories:
     order: 40
     labels:
       - 'chore'
-  - title: '🛠  Build'
+  - title: '🛠 Build'
     order: 50
     labels:
       - 'test'

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -89,10 +89,10 @@ release:
         - title: '🌐 Translation'
           labels:
             - 'translation'
-        - title: '⚙️  Dependencies'
+        - title: '⚙️ Dependencies'
           labels:
             - 'dependencies'
-        - title: '🛠  Build'
+        - title: '🛠 Build'
           labels:
             - 'build'
         - title: 'allcontributors'


### PR DESCRIPTION
See the title. If this has been done in purpose (two blanks), please just close it. 

If you keep it two and someone wants to adapt their categories and one uses 1 space instead of two, 0.9.1 fails with:

```
JReleaser for project neo4j-migrations-parent has not been properly configured.: JReleaser has not been properly configured.
[ERROR] java.util.MissingResourceException: Can't find resource for bundle java.util.PropertyResourceBundle, key validation_ares_missing
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```