### PR TITLE
Ignore files generated by Eclipse Import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,11 @@
 build/
 out/
 target/
-.classpath
-.project
 tmp/
 .DS_Store
 .tmp
+# Eclipse
+bin
+.classpath
+.project
+.settings


### PR DESCRIPTION
### Context
When the project is imported as a Gradle project in Eclipse, several files are created in the output directory '/bin' and '.settings' of each subproject.

<img width="901" alt="screenshot 2022-01-02 um 05 44 34" src="https://user-images.githubusercontent.com/265597/147867317-afc7e502-e7ea-4715-9b5f-3fae44bbdf19.png">


Adding 'bin' and '.settings' to .gitignore avoids that the project
contains unstaged files after import.

