### PR TITLE
[docs] Update Jbang instructions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -56,7 +56,6 @@ sdk install jreleaser
 
 *JBang*
 
-Requires Java 8
 [source]
 .stable
 ----


### PR DESCRIPTION
Removed "Required Java 8" from the Jbang instructions as this not really necessary given the fact Jbang can install Java when needed.
