### PR TITLE
[snap] versions need to be strings

### DIFF
--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/binary/snap/snap/snapcraft.yaml.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/binary/snap/snap/snapcraft.yaml.tpl
@@ -1,6 +1,6 @@
 # {{jreleaserCreationStamp}}
 name: {{snapPackageName}}
-version: {{projectVersion}}
+version: "{{projectVersion}}"
 summary: {{projectDescription}}
 description: {{projectLongDescription}}
 

--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/java-binary/snap/snap/snapcraft.yaml.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/java-binary/snap/snap/snapcraft.yaml.tpl
@@ -1,6 +1,6 @@
 # {{jreleaserCreationStamp}}
 name: {{snapPackageName}}
-version: {{projectVersion}}
+version: "{{projectVersion}}"
 summary: {{projectDescription}}
 description: {{projectLongDescription}}
 

--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/jlink/snap/snap/snapcraft.yaml.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/jlink/snap/snap/snapcraft.yaml.tpl
@@ -1,6 +1,6 @@
 # {{jreleaserCreationStamp}}
 name: {{snapPackageName}}
-version: {{projectVersion}}
+version: "{{projectVersion}}"
 summary: {{projectDescription}}
 description: {{projectLongDescription}}
 

--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/native-image/snap/snap/snapcraft.yaml.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/native-image/snap/snap/snapcraft.yaml.tpl
@@ -1,6 +1,6 @@
 # {{jreleaserCreationStamp}}
 name: {{snapPackageName}}
-version: {{projectVersion}}
+version: "{{projectVersion}}"
 summary: {{projectDescription}}
 description: {{projectLongDescription}}
 

--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/native-package/snap/snap/snapcraft.yaml.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/native-package/snap/snap/snapcraft.yaml.tpl
@@ -1,6 +1,6 @@
 # {{jreleaserCreationStamp}}
 name: {{snapPackageName}}
-version: {{projectVersion}}
+version: "{{projectVersion}}"
 summary: {{projectDescription}}
 description: {{projectLongDescription}}
 

--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/single-jar/snap/snap/snapcraft.yaml.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/single-jar/snap/snap/snapcraft.yaml.tpl
@@ -1,6 +1,6 @@
 # {{jreleaserCreationStamp}}
 name: {{snapPackageName}}
-version: {{projectVersion}}
+version: "{{projectVersion}}"
 summary: {{projectDescription}}
 description: {{projectLongDescription}}
 


### PR DESCRIPTION
<!-- The issue this PR addresses -->
<!-- Use "Fixes #xyz" if fixing a bug -->
<!-- Use "Resolves #xyz" if providing a feature -->
Fixes #766 

### Context
<!-- What problem does this change address? -->
<!-- Link to relevant issues or discussions here -->
A recent Snapcraft build of mcs v0.2 failed with 

> Issues while validating snapcraft.yaml: The 'version' property does not match the required schema: snap versions need to be strings. They must also be wrapped in quotes when the value will be interpreted by the YAML parser as a non-string. Examples: '1', '1.2', '1.2.3', git (will be replaced by a git describe based version string).

### Checklist
- [X] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [X] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
