### PR TITLE
Fix cosign-support by verifying against err-output

### DIFF
--- a/core/jreleaser-utils/src/main/java/org/jreleaser/util/command/CommandExecutor.java
+++ b/core/jreleaser-utils/src/main/java/org/jreleaser/util/command/CommandExecutor.java
@@ -99,6 +99,10 @@ public class CommandExecutor {
         return executeCommandCapturing(createProcessExecutor(command), out);
     }
 
+    public int executeCommandCapturing(Command command, OutputStream out, OutputStream err) throws CommandException {
+        return executeCommandCapturing(createProcessExecutor(command), out, err);
+    }
+
     public int executeCommandCapturing(Path directory, Command command, OutputStream out) throws CommandException {
         return executeCommandCapturing(createProcessExecutor(command)
             .directory(directory.toFile()), out);
@@ -136,8 +140,12 @@ public class CommandExecutor {
     }
 
     private int executeCommandCapturing(ProcessExecutor processor, OutputStream out) throws CommandException {
+        return executeCommandCapturing(processor, out, null);
+    }
+
+    private int executeCommandCapturing(ProcessExecutor processor, OutputStream out, OutputStream err) throws CommandException {
         try {
-            ByteArrayOutputStream err = new ByteArrayOutputStream();
+            ByteArrayOutputStream errLocal = new ByteArrayOutputStream();
 
             int exitValue = processor
                 .redirectOutput(out)
@@ -146,7 +154,11 @@ public class CommandExecutor {
                 .getExitValue();
 
             if (!quiet) {
-                error(err);
+                error(errLocal);
+            }
+
+            if (err != null) {
+                err.write(errLocal.toByteArray());
             }
 
             return exitValue;

--- a/sdks/tool-sdk/src/main/java/org/jreleaser/sdk/tool/AbstractTool.java
+++ b/sdks/tool-sdk/src/main/java/org/jreleaser/sdk/tool/AbstractTool.java
@@ -32,12 +32,14 @@ public class AbstractTool {
     protected final JReleaserContext context;
     protected final DownloadableTool tool;
     protected final String name;
+    protected final boolean verifyErrorOutput;
 
-    public AbstractTool(JReleaserContext context, String name, String version) {
+    public AbstractTool(JReleaserContext context, String name, String version, boolean verifyErrorOutput) {
         requireNonBlank(version, "'version' must not be blank");
         this.name = requireNonBlank(name, "'name' must not be blank");
         this.context = context;
-        this.tool = new DownloadableTool(context.getLogger(), name, version, PlatformUtils.getCurrentFull());
+        this.verifyErrorOutput = verifyErrorOutput;
+        this.tool = new DownloadableTool(context.getLogger(), name, version, PlatformUtils.getCurrentFull(), true);
     }
 
     public boolean setup() throws ToolException {

--- a/sdks/tool-sdk/src/main/java/org/jreleaser/sdk/tool/AbstractTool.java
+++ b/sdks/tool-sdk/src/main/java/org/jreleaser/sdk/tool/AbstractTool.java
@@ -34,6 +34,10 @@ public class AbstractTool {
     protected final String name;
     protected final boolean verifyErrorOutput;
 
+    public AbstractTool(JReleaserContext context, String name, String version) {
+        this(context, name, version, false);
+    }
+
     public AbstractTool(JReleaserContext context, String name, String version, boolean verifyErrorOutput) {
         requireNonBlank(version, "'version' must not be blank");
         this.name = requireNonBlank(name, "'name' must not be blank");

--- a/sdks/tool-sdk/src/main/java/org/jreleaser/sdk/tool/Cosign.java
+++ b/sdks/tool-sdk/src/main/java/org/jreleaser/sdk/tool/Cosign.java
@@ -40,7 +40,8 @@ import static org.jreleaser.util.StringUtils.isBlank;
  */
 public class Cosign extends AbstractTool {
     public Cosign(JReleaserContext context, String version) {
-        super(context, "cosign", version);
+        //Cosign outputs its version information on the err-channel
+        super(context, "cosign", version, true);
     }
 
     public boolean checkPassword(Path keyFile, byte[] password) {

--- a/sdks/tool-sdk/src/main/java/org/jreleaser/sdk/tool/Upx.java
+++ b/sdks/tool-sdk/src/main/java/org/jreleaser/sdk/tool/Upx.java
@@ -31,7 +31,7 @@ import java.util.List;
  */
 public class Upx extends AbstractTool {
     public Upx(JReleaserContext context, String version) {
-        super(context, "upx", version, false);
+        super(context, "upx", version);
     }
 
     public void compress(Path parent, List<String> args) throws CommandException {

--- a/sdks/tool-sdk/src/main/java/org/jreleaser/sdk/tool/Upx.java
+++ b/sdks/tool-sdk/src/main/java/org/jreleaser/sdk/tool/Upx.java
@@ -31,7 +31,7 @@ import java.util.List;
  */
 public class Upx extends AbstractTool {
     public Upx(JReleaserContext context, String version) {
-        super(context, "upx", version);
+        super(context, "upx", version, false);
     }
 
     public void compress(Path parent, List<String> args) throws CommandException {


### PR DESCRIPTION
Fixes #835

### Context

DownloadableTool should be able to also verify the err-output.
In the concrete case cosign is reporting its version via the error-channel, resulting in verify to always fail.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
