### PR TITLE
fix(chocolatey): Add a catchall pattern for tags trigger in  workflow

### DIFF
--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/binary/chocolatey/.github/workflows/push.yml.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/binary/chocolatey/.github/workflows/push.yml.tpl
@@ -3,6 +3,7 @@ name: Push-{{distributionName}}
 on:
   push:
     tags:
+      - '*'
     branches-ignore:
       - '**'
 

--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/java-binary/chocolatey/.github/workflows/push.yml.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/java-binary/chocolatey/.github/workflows/push.yml.tpl
@@ -3,6 +3,7 @@ name: Push-{{distributionName}}
 on:
   push:
     tags:
+      - '*'
     branches-ignore:
       - '**'
 

--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/jlink/chocolatey/.github/workflows/push.yml.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/jlink/chocolatey/.github/workflows/push.yml.tpl
@@ -3,6 +3,7 @@ name: Push-{{distributionName}}
 on:
   push:
     tags:
+      - '*'
     branches-ignore:
       - '**'
 

--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/native-image/chocolatey/.github/workflows/push.yml.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/native-image/chocolatey/.github/workflows/push.yml.tpl
@@ -3,6 +3,7 @@ name: Push-{{distributionName}}
 on:
   push:
     tags:
+      - '*'
     branches-ignore:
       - '**'
 

--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/native-package/chocolatey/.github/workflows/push.yml.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/native-package/chocolatey/.github/workflows/push.yml.tpl
@@ -3,6 +3,7 @@ name: Push-{{distributionName}}
 on:
   push:
     tags:
+      - '*'
     branches-ignore:
       - '**'
 


### PR DESCRIPTION
### Context

The GitHub documentation is very unclear on this point but without the
pattern, the workflow is not triggered at all when creating tags.

Tested on the Quarkus project: https://github.com/quarkusio/chocolatey-bucket/commit/ea8df1e7400499b9f2881f9091ecd7b5b230c92a

### Checklist
- [X] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [X] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
