### PR TITLE
feat(changelog): Do not include merge commits in the changelog

### DIFF
--- a/sdks/git-sdk/src/main/java/org/jreleaser/sdk/git/ChangelogGenerator.java
+++ b/sdks/git-sdk/src/main/java/org/jreleaser/sdk/git/ChangelogGenerator.java
@@ -115,6 +115,8 @@ public class ChangelogGenerator {
                 lineSeparator() +
                 StreamSupport.stream(commits.spliterator(), false)
                     .sorted(revCommitComparator)
+                    // Do not include merge commits
+                    .filter(commit -> commit.getParentCount() < 2)
                     .map(commit -> formatCommit(commit, commitsUrl, changelog, commitSeparator))
                     .collect(Collectors.joining(commitSeparator));
         } catch (GitAPIException e) {


### PR DESCRIPTION
Fixes #858

### Context
This prevents merge commits to be included in the changelog 

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
