### PR TITLE
feat(changelog): Introduce property to skip merge commits in the changelog. Resolves #858

### DIFF
--- a/core/jreleaser-model/src/main/java/org/jreleaser/model/Changelog.java
+++ b/core/jreleaser-model/src/main/java/org/jreleaser/model/Changelog.java
@@ -56,6 +56,7 @@ public class Changelog extends AbstractModelObject<Changelog> implements Domain,
 
     private Boolean enabled;
     private Boolean links;
+    private Boolean skipMergeCommits;
     private Sort sort = Sort.DESC;
     private String external;
     private Active formatted;
@@ -79,6 +80,7 @@ public class Changelog extends AbstractModelObject<Changelog> implements Domain,
         freezeCheck();
         this.enabled = merge(this.enabled, changelog.enabled);
         this.links = merge(this.links, changelog.links);
+        this.skipMergeCommits = merge(this.skipMergeCommits, changelog.skipMergeCommits);
         this.sort = merge(this.sort, changelog.sort);
         this.external = merge(this.external, changelog.external);
         this.formatted = merge(this.formatted, changelog.formatted);
@@ -136,9 +138,18 @@ public class Changelog extends AbstractModelObject<Changelog> implements Domain,
         return links != null && links;
     }
 
+    public boolean isSkipMergeCommits() {
+        return skipMergeCommits != null && skipMergeCommits;
+    }
+
     public void setLinks(Boolean links) {
         freezeCheck();
         this.links = links;
+    }
+
+    public void setSkipMergeCommits(Boolean skipMergeCommits) {
+        freezeCheck();
+        this.skipMergeCommits = skipMergeCommits;
     }
 
     public Sort getSort() {
@@ -293,6 +304,7 @@ public class Changelog extends AbstractModelObject<Changelog> implements Domain,
         map.put("enabled", isEnabled());
         map.put("external", external);
         map.put("links", isLinks());
+        map.put("skipMergeCommits", isSkipMergeCommits());
         map.put("sort", sort);
         map.put("formatted", formatted);
         map.put("preset", preset);

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/dsl/Changelog.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/dsl/Changelog.groovy
@@ -53,6 +53,8 @@ interface Changelog {
 
     Property<String> getPreset()
 
+    Property<Boolean> getSkipMergeCommits()
+
     RegularFileProperty getContentTemplate()
 
     void setContentTemplate(String contentTemplate)

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/ChangelogImpl.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/ChangelogImpl.groovy
@@ -43,6 +43,7 @@ class ChangelogImpl implements Changelog {
     final Property<Boolean> enabled
     final Property<Boolean> links
     final Property<Boolean> hideUncategorized
+    final Property<Boolean> skipMergeCommits
     final Property<org.jreleaser.model.Changelog.Sort> sort
     final RegularFileProperty external
     final Property<Active> formatted
@@ -66,6 +67,7 @@ class ChangelogImpl implements Changelog {
         enabled = objects.property(Boolean).convention(Providers.notDefined())
         links = objects.property(Boolean).convention(Providers.notDefined())
         hideUncategorized = objects.property(Boolean).convention(Providers.notDefined())
+        skipMergeCommits = objects.property(Boolean).convention(Providers.notDefined())
         sort = objects.property(org.jreleaser.model.Changelog.Sort).convention(Providers.notDefined())
         external = objects.fileProperty().convention(Providers.notDefined())
         formatted = objects.property(Active).convention(Providers.notDefined())
@@ -99,6 +101,7 @@ class ChangelogImpl implements Changelog {
     @Internal
     boolean isSet() {
             links.present ||
+            skipMergeCommits.present ||
             hideUncategorized.present ||
             external.present ||
             sort.present ||
@@ -208,6 +211,7 @@ class ChangelogImpl implements Changelog {
         if (!changelog.enabled) return changelog
 
         if (links.present) changelog.links = links.get()
+        if (skipMergeCommits.present) changelog.skipMergeCommits = skipMergeCommits.get()
         if (hideUncategorized.present) hide.uncategorized.set(hideUncategorized.get())
         if (sort.present) changelog.sort = sort.get()
         if (external.present) changelog.external = external.getAsFile().get().toPath()

--- a/sdks/git-sdk/git-sdk.gradle
+++ b/sdks/git-sdk/git-sdk.gradle
@@ -22,5 +22,6 @@ dependencies {
 
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito:mockito-junit-jupiter:$mockitoVersion"
+    testImplementation "org.mockito:mockito-inline:$mockitoVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"
 }


### PR DESCRIPTION
Fixes #858

### Context
The idea is to add a property "skipMergeCommits" and if set to true, merge commits will be skipped.
According to [git reference](https://git-scm.com/docs/git-commit-tree) we can rely on the number of parents to identify merge commits.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
