### PR TITLE
feat(changelog): Add warning when creating a changelog of shallow copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ tmp/
 .classpath
 .project
 .settings
+/bin/

--- a/core/jreleaser-utils/src/main/resources/org/jreleaser/bundle/Messages.properties
+++ b/core/jreleaser-utils/src/main/resources/org/jreleaser/bundle/Messages.properties
@@ -490,6 +490,7 @@ artifacts.no.match         = No matching artifacts. Skipping
 ERROR_unexpected_upload    = Unexpected error when uploading {}
 ERROR_unexpected_upload_to = Unexpected error when uploading to {}
 generic.git.warning        = Releasing to a generic Git repository is not supported
+changelog.shallow.warning  				= Generating a changelog from a shallow copy may cause a failure
 changelog.disabled                      = Changelog is not enabled. Skipping
 changelog.generator.resolve.commits     = resolving commits
 changelog.generator.sort.commits        = sorting commits {}

--- a/sdks/git-sdk/src/main/java/org/jreleaser/sdk/git/ChangelogGenerator.java
+++ b/sdks/git-sdk/src/main/java/org/jreleaser/sdk/git/ChangelogGenerator.java
@@ -179,6 +179,11 @@ public class ChangelogGenerator {
     }
 
     public Tags resolveTags(Git git, JReleaserContext context) throws GitAPIException {
+        GitSdk shallowTest = GitSdk.of(context);
+        if (shallowTest.isShallow()) {
+            context.getLogger().warn(RB.$("changelog.shallow.warning"));
+        }
+        
         List<Ref> tags = git.tagList().call();
 
         GitService gitService = context.getModel().getRelease().getGitService();

--- a/sdks/git-sdk/src/main/java/org/jreleaser/sdk/git/GitSdk.java
+++ b/sdks/git-sdk/src/main/java/org/jreleaser/sdk/git/GitSdk.java
@@ -37,6 +37,7 @@ import org.jreleaser.util.StringUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
@@ -197,7 +198,12 @@ public class GitSdk {
             throw new IOException(RB.$("ERROR_git_find_tag", tagName), e);
         }
     }
-
+    
+    public boolean isShallow() {
+        Path path = basedir.toPath();
+        return Files.exists(path.resolve(".git/shallow"));
+    }
+    
     public void tag(String tagName, JReleaserContext context) throws IOException {
         tag(tagName, false, context);
     }


### PR DESCRIPTION
Fixes #910 

### Context
Fixes the problem of not warning users of a possible failure when generating a changelog of a shallow copy.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
