### PR TITLE
fix: `projectNameCapitalized` now handles hyphens as spaces

### DIFF
--- a/core/jreleaser-model/src/main/java/org/jreleaser/model/GitService.java
+++ b/core/jreleaser-model/src/main/java/org/jreleaser/model/GitService.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.jreleaser.util.MustacheUtils.applyTemplates;
-import static org.jreleaser.util.StringUtils.getClassNameForLowerCaseHyphenSeparatedName;
+import static org.jreleaser.util.StringUtils.getCapitalizedName;
 import static org.jreleaser.util.StringUtils.isBlank;
 import static org.jreleaser.util.StringUtils.isNotBlank;
 import static org.jreleaser.util.Templates.resolveTemplate;
@@ -728,7 +728,7 @@ public abstract class GitService<S extends GitService<S>> extends AbstractModelO
         props.putAll(model.getEnvironment().getProperties());
         props.putAll(model.getEnvironment().getSourcedProperties());
         props.put(Constants.KEY_PROJECT_NAME, project.getName());
-        props.put(Constants.KEY_PROJECT_NAME_CAPITALIZED, getClassNameForLowerCaseHyphenSeparatedName(project.getName()));
+        props.put(Constants.KEY_PROJECT_NAME_CAPITALIZED, getCapitalizedName(project.getName()));
         props.put(Constants.KEY_PROJECT_VERSION, project.getVersion());
         props.put(Constants.KEY_PROJECT_STEREOTYPE, project.getStereotype());
         props.put(Constants.KEY_PROJECT_EFFECTIVE_VERSION, project.getEffectiveVersion());

--- a/core/jreleaser-model/src/main/java/org/jreleaser/model/JReleaserModel.java
+++ b/core/jreleaser-model/src/main/java/org/jreleaser/model/JReleaserModel.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static org.jreleaser.util.MustacheUtils.applyTemplates;
-import static org.jreleaser.util.StringUtils.getClassNameForLowerCaseHyphenSeparatedName;
+import static org.jreleaser.util.StringUtils.getCapitalizedName;
 import static org.jreleaser.util.StringUtils.isBlank;
 import static org.jreleaser.util.StringUtils.isNotBlank;
 
@@ -327,7 +327,7 @@ public class JReleaserModel implements Domain {
             props.put(Constants.KEY_COMMIT_FULL_HASH, commit.getFullHash());
         }
         props.put(Constants.KEY_PROJECT_NAME, project.getName());
-        props.put(Constants.KEY_PROJECT_NAME_CAPITALIZED, getClassNameForLowerCaseHyphenSeparatedName(project.getName()));
+        props.put(Constants.KEY_PROJECT_NAME_CAPITALIZED, getCapitalizedName(project.getName()));
         props.put(Constants.KEY_PROJECT_VERSION, project.getVersion());
         props.put(Constants.KEY_PROJECT_STEREOTYPE, project.getStereotype());
         props.put(Constants.KEY_PROJECT_EFFECTIVE_VERSION, project.getEffectiveVersion());

--- a/core/jreleaser-model/src/main/java/org/jreleaser/model/Project.java
+++ b/core/jreleaser-model/src/main/java/org/jreleaser/model/Project.java
@@ -40,7 +40,7 @@ import java.util.Map;
 
 import static org.jreleaser.util.JReleaserOutput.nag;
 import static org.jreleaser.util.MustacheUtils.applyTemplates;
-import static org.jreleaser.util.StringUtils.getClassNameForLowerCaseHyphenSeparatedName;
+import static org.jreleaser.util.StringUtils.getCapitalizedName;
 import static org.jreleaser.util.StringUtils.isBlank;
 import static org.jreleaser.util.StringUtils.isNotBlank;
 import static org.jreleaser.util.Templates.resolveTemplate;
@@ -679,7 +679,7 @@ public class Project extends AbstractModelObject<Project> implements Domain, Ext
             props.putAll(model.getEnvironment().getProperties());
             props.putAll(model.getEnvironment().getSourcedProperties());
             props.put(Constants.KEY_PROJECT_NAME, project.getName());
-            props.put(Constants.KEY_PROJECT_NAME_CAPITALIZED, getClassNameForLowerCaseHyphenSeparatedName(project.getName()));
+            props.put(Constants.KEY_PROJECT_NAME_CAPITALIZED, getCapitalizedName(project.getName()));
             props.put(Constants.KEY_PROJECT_STEREOTYPE, project.getStereotype());
             props.put(Constants.KEY_PROJECT_VERSION, project.getVersion());
             props.put(Constants.KEY_PROJECT_SNAPSHOT, String.valueOf(project.isSnapshot()));

--- a/core/jreleaser-model/src/test/java/org/jreleaser/model/JReleaserModelTest.java
+++ b/core/jreleaser-model/src/test/java/org/jreleaser/model/JReleaserModelTest.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2022 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.model;
+
+import org.jreleaser.util.Constants;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JReleaserModelTest {
+
+    @Test
+    void shouldRenderProjectNameCapitalizedWithSpaces() {
+        JReleaserModel model = new JReleaserModel();
+        model.getProject().setName("quarkiverse-parent");
+        model.getRelease().setGithub(new Github());
+        Map<String, Object> props = model.props();
+        assertEquals("Quarkiverse Parent", props.get(Constants.KEY_PROJECT_NAME_CAPITALIZED));
+    }
+}

--- a/core/jreleaser-utils/src/main/java/org/jreleaser/util/StringUtils.java
+++ b/core/jreleaser-utils/src/main/java/org/jreleaser/util/StringUtils.java
@@ -204,6 +204,38 @@ public class StringUtils {
     }
 
     /**
+     * Converts foo-bar into Foo Bar. Empty and null strings are returned
+     * as-is.
+     *
+     * @param name The lower case hyphen separated name
+     * @return The capitalized name equivalent.
+     */
+    public static String getCapitalizedName(String name) {
+        // Handle null and empty strings.
+        if (isBlank(name)) {
+            return name;
+        }
+
+        if (name.contains("-")) {
+            StringBuilder buf = new StringBuilder();
+            String[] tokens = name.split("-");
+            for (String token : tokens) {
+                if (token == null || token.length() == 0) {
+                    continue;
+                }
+                if (buf.length() > 0) {
+                    buf.append(' ');
+                }
+                buf.append(capitalize(token));
+            }
+
+            return buf.toString();
+        }
+
+        return capitalize(name);
+    }
+
+    /**
      * Retrieves the logical class name of a Griffon artifact given the Griffon class
      * and a specified trailing name
      *


### PR DESCRIPTION
- Fixes #923

### Context
It fixes the `projectNameCapitalized` behavior

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.