### PR TITLE
build: Update use of set-output in workflows

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -33,7 +33,7 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo ::set-output name=VERSION::$(cat VERSION)
+          echo "VERSION=$(cat VERSION)" >>$GITHUB_OUTPUT
 
   jlink:
     needs: [precheck]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo ::set-output name=VERSION::${{ github.event.inputs.version }}
+          echo "VERSION=${{ github.event.inputs.version }}" >>$GITHUB_OUTPUT
 
   jlink:
     needs: [precheck]

--- a/.github/workflows/smoke-tests-ant.yml
+++ b/.github/workflows/smoke-tests-ant.yml
@@ -23,7 +23,7 @@ jobs:
         shell: bash
         run: |
           version=$(cat VERSION)
-          echo ::set-output name=VERSION::$(echo "$version")
+          echo "VERSION=$(echo "$version")"  >>$GITHUB_OUTPUT
 
   build:
     needs: [ precheck ]

--- a/.github/workflows/smoke-tests-cli.yml
+++ b/.github/workflows/smoke-tests-cli.yml
@@ -23,7 +23,7 @@ jobs:
         shell: bash
         run: |
           version=$(cat VERSION)
-          echo ::set-output name=VERSION::$(echo "$version")
+          echo "VERSION=$(echo "$version")" >>$GITHUB_OUTPUT
 
   build:
     needs: [ precheck ]

--- a/.github/workflows/smoke-tests-gradle.yml
+++ b/.github/workflows/smoke-tests-gradle.yml
@@ -23,7 +23,7 @@ jobs:
         shell: bash
         run: |
           version=$(cat VERSION)
-          echo ::set-output name=VERSION::$(echo "$version")
+          echo "VERSION=$(echo "$version")" >>$GITHUB_OUTPUT
 
   build:
     needs: [ precheck ]

--- a/.github/workflows/smoke-tests-maven.yml
+++ b/.github/workflows/smoke-tests-maven.yml
@@ -23,7 +23,7 @@ jobs:
         shell: bash
         run: |
           version=$(cat VERSION)
-          echo ::set-output name=VERSION::$(echo "$version")
+          echo "VERSION=$(echo "$version")" >>$GITHUB_OUTPUT
 
   build:
     needs: [ precheck ]

--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/binary/appimage/.github/workflows/release.yml.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/binary/appimage/.github/workflows/release.yml.tpl
@@ -17,8 +17,8 @@ jobs:
       - name: Variables
         id: vars
         run: |
-          echo ::set-output name=version::$(cat VERSION)
-          echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
+          echo "version=$(cat VERSION)" >>$GITHUB_OUTPUT
+          echo "tag=${GITHUB_REF#refs/tags/}" >>$GITHUB_OUTPUT
 
       - name: Create the AppImage
         run: sh create-appimage.sh

--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/java-binary/appimage/.github/workflows/release.yml.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/java-binary/appimage/.github/workflows/release.yml.tpl
@@ -17,8 +17,8 @@ jobs:
       - name: Variables
         id: vars
         run: |
-          echo ::set-output name=version::$(cat VERSION)
-          echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
+          echo "version=$(cat VERSION)" >>$GITHUB_OUTPUT
+          echo "tag=${GITHUB_REF#refs/tags/}" >>$GITHUB_OUTPUT
 
       - name: Create the AppImage
         run: sh create-appimage.sh

--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/jlink/appimage/.github/workflows/release.yml.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/jlink/appimage/.github/workflows/release.yml.tpl
@@ -17,8 +17,8 @@ jobs:
       - name: Variables
         id: vars
         run: |
-          echo ::set-output name=version::$(cat VERSION)
-          echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
+          echo "version=$(cat VERSION)" >>$GITHUB_OUTPUT
+          echo "tag=${GITHUB_REF#refs/tags/}" >>$GITHUB_OUTPUT
 
       - name: Create the AppImage
         run: sh create-appimage.sh

--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/native-image/appimage/.github/workflows/release.yml.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/native-image/appimage/.github/workflows/release.yml.tpl
@@ -17,8 +17,8 @@ jobs:
       - name: Variables
         id: vars
         run: |
-          echo ::set-output name=version::$(cat VERSION)
-          echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
+          echo "version=$(cat VERSION)" >>$GITHUB_OUTPUT
+          echo "tag=${GITHUB_REF#refs/tags/}" >>$GITHUB_OUTPUT
 
       - name: Create the AppImage
         run: sh create-appimage.sh

--- a/src/jreleaser/distributions/jreleaser-standalone/appimage/.github/workflows/release.yml.tpl
+++ b/src/jreleaser/distributions/jreleaser-standalone/appimage/.github/workflows/release.yml.tpl
@@ -17,8 +17,8 @@ jobs:
       - name: Variables
         id: vars
         run: |
-          echo ::set-output name=version::$(cat VERSION)
-          echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
+          echo "version=$(cat VERSION)" >>$GITHUB_OUTPUT
+          echo "tag=${GITHUB_REF#refs/tags/}" >>$GITHUB_OUTPUT
 
       - name: Create the AppImage
         run: sh create-appimage.sh


### PR DESCRIPTION
<!-- The issue this PR addresses -->
<!-- Please reference the issue this PR solves -->
Fixes https://github.com/jreleaser/jreleaser/issues/983

### Context

GitHub Actions will issue a warning when ::set-output is used.

`The set-output command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information, see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/`
<!-- What problem does this change address? -->
<!-- Link to relevant issues or discussions here -->

https://hynek.me/til/set-output-deprecation-github-actions/

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
