### PR TITLE
i18n: Fix Italian translation of CLI resources.

### DIFF
--- a/plugins/jreleaser/src/main/resources/org/jreleaser/cli/Messages_it.properties
+++ b/plugins/jreleaser/src/main/resources/org/jreleaser/cli/Messages_it.properties
@@ -20,14 +20,14 @@
 # Shared
 ###############################################################################
 # header
-usage.headerHeading      = JReleaser √® un tool di rilascio automatizzato per progetti Java.%n
-jreleaser.usage.header.0 = Il suo obiettivo √® semplificare la creazione di rilasci e
+usage.headerHeading      = JReleaser Ë un tool di rilascio automatizzato per progetti Java.%n
+jreleaser.usage.header.0 = Il suo obiettivo Ë semplificare la creazione di rilasci e
 jreleaser.usage.header.1 = la pubblicazione di artefatti su molteplici gestori di pacchetti,
 jreleaser.usage.header.2 = fornendo opzioni personalizzabili.
 usage.synopsisHeading    = %nUso:\u0020
 usage.optionListHeading  = %nOpzioni:%n
 usage.commandListHeading = %nComandi:%n
-usage.footerHeading      = %nLa documentazione √® disponibile su https://jreleaser.org%n
+usage.footerHeading      = %nLa documentazione Ë disponibile su https://jreleaser.org%n
 helpCommand.command      = COMANDO
 help                     = Mostra questo messaggio di aiuto e termina l'esecuzione.
 version                  = Stampa le informazioni sulla versione ed termina l'esecuzione.
@@ -69,8 +69,8 @@ ERROR_unexpected_error = Errore inaspettato
 # options
 config-file     = Il file di configurazione.
 git-root-search = Cerca la directory di base GIT.
-system-property = Imposta una propriet√† di sistema. Ripetibile.
-set-property    = Imposta il valore di una propriet√†. Ripetibile.
+system-property = Imposta una propriet‡ di sistema. Ripetibile.
+set-property    = Imposta il valore di una propriet‡. Ripetibile.
 # text
 TEXT_config_file = Configura con {}
 TEXT_basedir_set = - Cartella di base 'basedir' impostata a {}
@@ -78,7 +78,7 @@ TEXT_basedir_set = - Cartella di base 'basedir' impostata a {}
 ERROR_missing_config_file     = Manca l'opzione necessaria: '--config-file=<configFile>' o il file locale denominato 'jreleaser[{}]'
 ERROR_missing_required_option = Opzione necessaria mancante: '{}'
 ERROR_invalid_config_format   = Formato di configurazione non valido: {}
-ERROR_invalid_property        = Propriet√† '{}' non valida
+ERROR_invalid_property        = Propriet‡ '{}' non valida
 
 ###############################################################################
 # Shared - AbstractPlatformAwareModelCommand
@@ -146,7 +146,7 @@ jreleaser.init.TEXT_writing_file   = Scrittura file {}
 jreleaser.init.TEXT_success        = JReleaser inizializzato su {}
 # errors
 jreleaser.init.ERROR_invalid_format = Formato file non supportato. Formati possibili: [{}]
-jreleaser.init.ERROR_file_exists    = Il file {} esiste gi√® e la sovrascrittura non √® consentita.
+jreleaser.init.ERROR_file_exists    = Il file {} esiste gi‡ e la sovrascrittura non Ë consentita.
 
 ###############################################################################
 # Package
@@ -193,9 +193,9 @@ jreleaser.release.tag-name                        = Tag del rilascio.
 jreleaser.release.previous-tag-name               = Tag della versione precedente.
 jreleaser.release.release-name                    = Nome del rilascio.
 jreleaser.release.milestone-name                  = Nome della milestone.
-jreleaser.release.prerelease                      = Se È un pre-rilascio.
+jreleaser.release.prerelease                      = Se Ë un pre-rilascio.
 jreleaser.release.prerelease-pattern              = Pattern del pre-rilascio.
-jreleaser.release.draft                           = Se il rilascio È una bozza.
+jreleaser.release.draft                           = Se il rilascio Ë una bozza.
 jreleaser.release.overwrite                       = Sovrascrivi una versione esistente.
 jreleaser.release.update                          = Aggiorna una versione esistente.
 jreleaser.release.update-section                  = Sezione del rilascio da aggiornare. Ripetibile.


### PR DESCRIPTION
### Context
This fixes some wrong characters in the Italian translation.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
