### PR TITLE
fix: Detect title of commits with both line ending

### DIFF
--- a/sdks/jreleaser-git-java-sdk/src/main/java/org/jreleaser/sdk/git/ChangelogGenerator.java
+++ b/sdks/jreleaser-git-java-sdk/src/main/java/org/jreleaser/sdk/git/ChangelogGenerator.java
@@ -636,13 +636,8 @@ public class ChangelogGenerator {
         }
 
         private static String[] split(String str) {
-            // try Windows first
-            String sep = "\r\n";
-            if (str.contains(sep)) {
-                return str.split(sep);
-            }
-
-            return str.split("\n");
+            // Any Unicode linebreak sequence
+            return str.split("\\R");
         }
     }
 


### PR DESCRIPTION
GitHub's Dependabot has commits that contain both CR/LF and LF, the previous logic did not always split the commit message correctly

Fixes: #1042

### Context
<!-- What problem does this change address? -->
<!-- Link to relevant issues or discussions here -->

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
