### PR TITLE
feat(changelog): handle BREAKING CHANGE from footer

### DIFF
--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/release/BaseReleaserValidator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/release/BaseReleaserValidator.java
@@ -294,10 +294,6 @@ public abstract class BaseReleaserValidator extends Validator {
             changelog.setSort(org.jreleaser.model.Changelog.Sort.DESC);
         }
 
-        if (isBlank(changelog.getFormat())) {
-            changelog.setFormat("- {{commitShortHash}} {{commitTitle}} ({{commitAuthor}})");
-        }
-
         if (isBlank(changelog.getCategoryTitleFormat())) {
             changelog.setCategoryTitleFormat("## {{categoryTitle}}");
         }
@@ -323,6 +319,11 @@ public abstract class BaseReleaserValidator extends Validator {
 
         if (isNotBlank(changelog.getPreset())) {
             loadPreset(context, changelog, errors);
+        }
+
+        // set the default format after the preset, as preset can contain a default format too
+        if (isBlank(changelog.getFormat())) {
+            changelog.setFormat("- {{commitShortHash}} {{commitTitle}} ({{commitAuthor}})");
         }
 
         if (changelog.getCategories().isEmpty()) {
@@ -423,6 +424,10 @@ public abstract class BaseReleaserValidator extends Validator {
 
             if (null != inputStream) {
                 Changelog loaded = JReleaserConfigLoader.load(Changelog.class, presetFileName, inputStream);
+
+                if(isBlank(changelog.getFormat())) {
+                    changelog.setFormat(loaded.getFormat());
+                }
 
                 Set<Changelog.Labeler> labelersCopy = new TreeSet<>(Changelog.Labeler.ORDER);
                 labelersCopy.addAll(changelog.getLabelers());

--- a/core/jreleaser-model-impl/src/main/resources/META-INF/jreleaser/changelog/preset-conventional-commits.yml
+++ b/core/jreleaser-model-impl/src/main/resources/META-INF/jreleaser/changelog/preset-conventional-commits.yml
@@ -81,10 +81,4 @@ categories:
     labels:
       - 'docs'
 
-replacers:
-  - search: '((?:build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(?:\(.*\))?)!(:\s.*)'
-    replace: '🚨 $1$2'
-  - search: '(?:build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)\((.*)\):\s(.*)'
-    replace: '\*\*$1\*\*: $2'
-  - search: '(?:build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test):\s(.*)'
-    replace: '$1'
+format: '- {{commitShortHash}} {{#commitIsConventional}}{{#conventionalCommitIsBreakingChange}}🚨 {{/conventionalCommitIsBreakingChange}}{{#conventionalCommitScope}}**{{conventionalCommitScope}}**: {{/conventionalCommitScope}}{{conventionalCommitDescription}}{{#conventionalCommitBreakingChangeContent}} - *{{conventionalCommitBreakingChangeContent}}*{{/conventionalCommitBreakingChangeContent}}{{/commitIsConventional}}{{^commitIsConventional}}{{commitTitle}}{{/commitIsConventional}}'

--- a/sdks/jreleaser-git-java-sdk/src/test/java/org/jreleaser/sdk/git/ConventionalCommitUnitTest.java
+++ b/sdks/jreleaser-git-java-sdk/src/test/java/org/jreleaser/sdk/git/ConventionalCommitUnitTest.java
@@ -1,0 +1,355 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2022 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.sdk.git;
+
+import org.eclipse.jgit.lib.AbbreviatedObjectId;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.jreleaser.model.internal.release.Changelog;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ConventionalCommitUnitTest {
+
+    private ChangelogGenerator.Commit mockCommit(String commitBody) {
+        RevCommit revCommit = mock(RevCommit.class);
+        ObjectId objectId = mock(ObjectId.class);
+        AbbreviatedObjectId abbreviatedObjectId = mock(AbbreviatedObjectId.class);
+        PersonIdent committer = mock(PersonIdent.class);
+        PersonIdent author = mock(PersonIdent.class);
+        Changelog changelog = mock(Changelog.class);
+        int time = 123456;
+
+        when(revCommit.getId()).thenReturn(objectId);
+        when(objectId.name()).thenReturn("full-hash");
+        when(objectId.abbreviate(7)).thenReturn(abbreviatedObjectId);
+        when(abbreviatedObjectId.name()).thenReturn("short-hash");
+        when(revCommit.getFullMessage()).thenReturn(commitBody);
+        when(revCommit.getCommitterIdent()).thenReturn(committer);
+        when(committer.getName()).thenReturn("committer-name");
+        when(committer.getEmailAddress()).thenReturn("committer@example.com");
+        when(revCommit.getAuthorIdent()).thenReturn(author);
+        when(author.getName()).thenReturn("author-name");
+        when(author.getEmailAddress()).thenReturn("author@example.com");
+        when(revCommit.getCommitTime()).thenReturn(time);
+        when(changelog.getPreset()).thenReturn("conventional-commits");
+
+        return ChangelogGenerator.ConventionalCommit.of(revCommit);
+    }
+
+    @Test
+    public void badlyFormattedCommitIsNotConventional() {
+        String commitBody = "featadd new feature";
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody);
+
+        assertThat(c)
+            .isInstanceOf(ChangelogGenerator.Commit.class)
+            .isNotInstanceOf(ChangelogGenerator.ConventionalCommit.class);
+    }
+
+    @Test
+    public void typeCanBeAnyWord() {
+        String commitBody = "whatever: correct spelling of CHANGELOG";
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody);
+
+        assertThat(c)
+            .hasFieldOrPropertyWithValue("isConventional", true)
+            .hasFieldOrPropertyWithValue("ccIsBreakingChange", false)
+            .hasFieldOrPropertyWithValue("ccBreakingChangeContent", "")
+            .hasFieldOrPropertyWithValue("ccType", "whatever")
+            .hasFieldOrPropertyWithValue("ccScope", "")
+            .hasFieldOrPropertyWithValue("ccDescription", "correct spelling of CHANGELOG")
+            .hasFieldOrPropertyWithValue("ccBody", "");
+        assertThat(((ChangelogGenerator.ConventionalCommit) c).getTrailers()).isEmpty();
+    }
+
+    @Test
+    public void bangIsBreakingChange() {
+        String commitBody = "feat(scope)!: add new feature";
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody);
+
+        assertThat(c)
+            .hasFieldOrPropertyWithValue("isConventional", true)
+            .hasFieldOrPropertyWithValue("ccIsBreakingChange", true)
+            .hasFieldOrPropertyWithValue("ccBreakingChangeContent", "")
+            .hasFieldOrPropertyWithValue("ccType", "feat")
+            .hasFieldOrPropertyWithValue("ccScope", "scope")
+            .hasFieldOrPropertyWithValue("ccDescription", "add new feature")
+            .hasFieldOrPropertyWithValue("ccBody", "");
+        assertThat(((ChangelogGenerator.ConventionalCommit) c).getTrailers()).isEmpty();
+    }
+
+    @Test
+    public void singleLineBreakingChange() {
+        String commitBody = "feat(scope): add new feature\n" +
+            "\n" +
+            "BREAKING CHANGE: single line breaking change";
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody);
+
+        assertThat(c)
+            .hasFieldOrPropertyWithValue("isConventional", true)
+            .hasFieldOrPropertyWithValue("ccIsBreakingChange", true)
+            .hasFieldOrPropertyWithValue("ccBreakingChangeContent", "single line breaking change")
+            .hasFieldOrPropertyWithValue("ccType", "feat")
+            .hasFieldOrPropertyWithValue("ccScope", "scope")
+            .hasFieldOrPropertyWithValue("ccDescription", "add new feature")
+            .hasFieldOrPropertyWithValue("ccBody", "");
+        assertThat(((ChangelogGenerator.ConventionalCommit) c).getTrailers()).isEmpty();
+    }
+
+    @Test
+    public void singleLineBreakingChangeWithDash() {
+        String commitBody = "feat(scope): add new feature\n" +
+            "\n" +
+            "BREAKING-CHANGE: single line breaking change";
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody);
+
+        assertThat(c)
+            .hasFieldOrPropertyWithValue("isConventional", true)
+            .hasFieldOrPropertyWithValue("ccIsBreakingChange", true)
+            .hasFieldOrPropertyWithValue("ccBreakingChangeContent", "single line breaking change")
+            .hasFieldOrPropertyWithValue("ccType", "feat")
+            .hasFieldOrPropertyWithValue("ccScope", "scope")
+            .hasFieldOrPropertyWithValue("ccDescription", "add new feature")
+            .hasFieldOrPropertyWithValue("ccBody", "");
+        assertThat(((ChangelogGenerator.ConventionalCommit) c).getTrailers()).isEmpty();
+    }
+
+    @Test
+    public void singleLineBreakingChangeLowerCase() {
+        String commitBody = "feat(scope): add new feature\n" +
+            "\n" +
+            "breaking CHANGE: single line breaking change";
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody);
+
+        assertThat(c)
+            .hasFieldOrPropertyWithValue("isConventional", true)
+            .hasFieldOrPropertyWithValue("ccIsBreakingChange", false)
+            .hasFieldOrPropertyWithValue("ccBreakingChangeContent", "")
+            .hasFieldOrPropertyWithValue("ccType", "feat")
+            .hasFieldOrPropertyWithValue("ccScope", "scope")
+            .hasFieldOrPropertyWithValue("ccDescription", "add new feature")
+            .hasFieldOrPropertyWithValue("ccBody", "breaking CHANGE: single line breaking change");
+        assertThat(((ChangelogGenerator.ConventionalCommit) c).getTrailers()).isEmpty();
+    }
+
+    @Test
+    public void multiLineBreakingChange() {
+        String commitBody = "feat(scope): add new feature\n" +
+            "\n" +
+            "BREAKING CHANGE: multi line\n" +
+            "breaking change";
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody);
+
+        assertThat(c)
+            .hasFieldOrPropertyWithValue("isConventional", true)
+            .hasFieldOrPropertyWithValue("ccIsBreakingChange", true)
+            .hasFieldOrPropertyWithValue("ccBreakingChangeContent", "multi line\nbreaking change")
+            .hasFieldOrPropertyWithValue("ccType", "feat")
+            .hasFieldOrPropertyWithValue("ccScope", "scope")
+            .hasFieldOrPropertyWithValue("ccDescription", "add new feature")
+            .hasFieldOrPropertyWithValue("ccBody", "");
+        assertThat(((ChangelogGenerator.ConventionalCommit) c).getTrailers()).isEmpty();
+    }
+
+    @Test
+    public void singleLineBreakingChangeFollowedByGitTrailer() {
+        String commitBody = "feat(scope): add new feature\n" +
+            "\n" +
+            "BREAKING CHANGE: single line breaking change\n" +
+            "Reviewed-by: Z\n" +
+            "Closes #42";
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody);
+
+        assertThat(c)
+            .hasFieldOrPropertyWithValue("isConventional", true)
+            .hasFieldOrPropertyWithValue("ccIsBreakingChange", true)
+            .hasFieldOrPropertyWithValue("ccBreakingChangeContent", "single line breaking change");
+        assertThat(((ChangelogGenerator.ConventionalCommit) c).getTrailers())
+            .hasSize(2)
+            .containsExactlyInAnyOrder(new ChangelogGenerator.ConventionalCommit.Trailer("Reviewed-by", "Z"), new ChangelogGenerator.ConventionalCommit.Trailer("Closes", "42"));
+    }
+
+    @Test
+    public void ccExample1() {
+        String commitBody = "feat: allow provided config object to extend other configs\n" +
+            "\n" +
+            "BREAKING CHANGE: `extends` key in config file is now used for extending other config files";
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody);
+
+        assertThat(c)
+            .hasFieldOrPropertyWithValue("isConventional", true)
+            .hasFieldOrPropertyWithValue("ccIsBreakingChange", true)
+            .hasFieldOrPropertyWithValue("ccBreakingChangeContent", "`extends` key in config file is now used for extending other config files")
+            .hasFieldOrPropertyWithValue("ccType", "feat")
+            .hasFieldOrPropertyWithValue("ccScope", "")
+            .hasFieldOrPropertyWithValue("ccDescription", "allow provided config object to extend other configs")
+            .hasFieldOrPropertyWithValue("ccBody", "");
+        assertThat(((ChangelogGenerator.ConventionalCommit) c).getTrailers()).isEmpty();
+    }
+
+    @Test
+    public void ccExample2() {
+        String commitBody = "feat!: send an email to the customer when a product is shipped";
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody);
+
+        assertThat(c)
+            .hasFieldOrPropertyWithValue("isConventional", true)
+            .hasFieldOrPropertyWithValue("ccIsBreakingChange", true)
+            .hasFieldOrPropertyWithValue("ccBreakingChangeContent", "")
+            .hasFieldOrPropertyWithValue("ccType", "feat")
+            .hasFieldOrPropertyWithValue("ccScope", "")
+            .hasFieldOrPropertyWithValue("ccDescription", "send an email to the customer when a product is shipped")
+            .hasFieldOrPropertyWithValue("ccBody", "");
+        assertThat(((ChangelogGenerator.ConventionalCommit) c).getTrailers()).isEmpty();
+    }
+
+    @Test
+    public void ccExample3() {
+        String commitBody = "feat(api)!: send an email to the customer when a product is shipped";
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody);
+
+        assertThat(c)
+            .hasFieldOrPropertyWithValue("isConventional", true)
+            .hasFieldOrPropertyWithValue("ccIsBreakingChange", true)
+            .hasFieldOrPropertyWithValue("ccBreakingChangeContent", "")
+            .hasFieldOrPropertyWithValue("ccType", "feat")
+            .hasFieldOrPropertyWithValue("ccScope", "api")
+            .hasFieldOrPropertyWithValue("ccDescription", "send an email to the customer when a product is shipped")
+            .hasFieldOrPropertyWithValue("ccBody", "");
+        assertThat(((ChangelogGenerator.ConventionalCommit) c).getTrailers()).isEmpty();
+
+        assertThat(c.asContext(false, ""))
+            .containsEntry("commitIsConventional", true)
+            .containsEntry("conventionalCommitBreakingChangeContent", "")
+            .containsEntry("conventionalCommitIsBreakingChange", true)
+            .containsEntry("conventionalCommitType", "!!feat!!")
+            .containsEntry("conventionalCommitScope", "!!api!!")
+            .containsEntry("conventionalCommitDescription", "!!send an email to the customer when a product is shipped!!")
+            .containsEntry("conventionalCommitBody", "");
+    }
+
+    @Test
+    public void ccExample4() {
+        String commitBody = "chore!: drop support for Node 6\n" +
+            "\n" +
+            "BREAKING CHANGE: use JavaScript features not available in Node 6.";
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody);
+
+        assertThat(c)
+            .hasFieldOrPropertyWithValue("isConventional", true)
+            .hasFieldOrPropertyWithValue("ccIsBreakingChange", true)
+            .hasFieldOrPropertyWithValue("ccBreakingChangeContent", "use JavaScript features not available in Node 6.")
+            .hasFieldOrPropertyWithValue("ccType", "chore")
+            .hasFieldOrPropertyWithValue("ccScope", "")
+            .hasFieldOrPropertyWithValue("ccDescription", "drop support for Node 6")
+            .hasFieldOrPropertyWithValue("ccBody", "");
+        assertThat(((ChangelogGenerator.ConventionalCommit) c).getTrailers()).isEmpty();
+
+        assertThat(c.asContext(false, ""))
+            .containsEntry("commitIsConventional", true)
+            .containsEntry("conventionalCommitBreakingChangeContent", "!!use JavaScript features not available in Node 6.!!")
+            .containsEntry("conventionalCommitIsBreakingChange", true)
+            .containsEntry("conventionalCommitType", "!!chore!!")
+            .containsEntry("conventionalCommitScope", "")
+            .containsEntry("conventionalCommitDescription", "!!drop support for Node 6!!")
+            .containsEntry("conventionalCommitBody", "");
+    }
+
+    @Test
+    public void ccExample5() {
+        String commitBody = "docs: correct spelling of CHANGELOG";
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody);
+
+        assertThat(c)
+            .hasFieldOrPropertyWithValue("isConventional", true)
+            .hasFieldOrPropertyWithValue("ccIsBreakingChange", false)
+            .hasFieldOrPropertyWithValue("ccBreakingChangeContent", "")
+            .hasFieldOrPropertyWithValue("ccType", "docs")
+            .hasFieldOrPropertyWithValue("ccScope", "")
+            .hasFieldOrPropertyWithValue("ccDescription", "correct spelling of CHANGELOG")
+            .hasFieldOrPropertyWithValue("ccBody", "");
+        assertThat(((ChangelogGenerator.ConventionalCommit) c).getTrailers()).isEmpty();
+    }
+
+    @Test
+    public void ccExample6() {
+        String commitBody = "feat(lang): add Polish language";
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody);
+
+        assertThat(c)
+            .hasFieldOrPropertyWithValue("isConventional", true)
+            .hasFieldOrPropertyWithValue("ccIsBreakingChange", false)
+            .hasFieldOrPropertyWithValue("ccBreakingChangeContent", "")
+            .hasFieldOrPropertyWithValue("ccType", "feat")
+            .hasFieldOrPropertyWithValue("ccScope", "lang")
+            .hasFieldOrPropertyWithValue("ccDescription", "add Polish language")
+            .hasFieldOrPropertyWithValue("ccBody", "");
+        assertThat(((ChangelogGenerator.ConventionalCommit) c).getTrailers()).isEmpty();
+    }
+
+    @Test
+    public void ccExample7() {
+        String commitBody = "fix: prevent racing of requests\n" +
+            "\n" +
+            "Introduce a request id and a reference to latest request. Dismiss\n" +
+            "incoming responses other than from latest request.\n" +
+            "\n" +
+            "Remove timeouts which were used to mitigate the racing issue but are\n" +
+            "obsolete now.\n" +
+            "\n" +
+            "Reviewed-by: Z\n" +
+            "Refs: #123";
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody);
+
+        assertThat(c)
+            .hasFieldOrPropertyWithValue("isConventional", true)
+            .hasFieldOrPropertyWithValue("ccIsBreakingChange", false)
+            .hasFieldOrPropertyWithValue("ccBreakingChangeContent", "")
+            .hasFieldOrPropertyWithValue("ccType", "fix")
+            .hasFieldOrPropertyWithValue("ccScope", "")
+            .hasFieldOrPropertyWithValue("ccDescription", "prevent racing of requests")
+            .hasFieldOrPropertyWithValue("ccBody", "Introduce a request id and a reference to latest request. Dismiss\n" +
+                "incoming responses other than from latest request.\n" +
+                "\n" +
+                "Remove timeouts which were used to mitigate the racing issue but are\n" +
+                "obsolete now.");
+        assertThat(((ChangelogGenerator.ConventionalCommit) c).getTrailers())
+            .hasSize(2)
+            .containsExactlyInAnyOrder(new ChangelogGenerator.ConventionalCommit.Trailer("Reviewed-by", "Z"), new ChangelogGenerator.ConventionalCommit.Trailer("Refs", "#123"));
+    }
+}


### PR DESCRIPTION
Fixes #809

### Context
Introduces a new ConventionalCommit subtype of Commit, which parses the commit body according to conventional commit specification. The conventional-commit preset uses a custom changelog.format instead of replacers to achieve formatting. The changelog presets can now have a custom format.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
