### PR TITLE
reference closed issues in changelog

### DIFF
--- a/api/jreleaser-utils/src/main/java/org/jreleaser/util/StringUtils.java
+++ b/api/jreleaser-utils/src/main/java/org/jreleaser/util/StringUtils.java
@@ -651,6 +651,7 @@ public class StringUtils {
     }
 
     public static String escapeRegexChars(String str) {
+        if (str.isEmpty()) return "";
         boolean start = false;
         boolean end = false;
 

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/JReleaserModel.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/JReleaserModel.java
@@ -539,7 +539,7 @@ public class JReleaserModel {
         props.put(Constants.KEY_SRC_URL, service.getResolvedSrcUrl(this));
         props.put(Constants.KEY_RELEASE_NOTES_URL, service.getResolvedReleaseNotesUrl(this));
         props.put(Constants.KEY_LATEST_RELEASE_URL, service.getResolvedLatestReleaseUrl(this));
-        props.put(Constants.KEY_ISSUE_TRACKER_URL, service.getResolvedIssueTrackerUrl(this));
+        props.put(Constants.KEY_ISSUE_TRACKER_URL, service.getResolvedIssueTrackerUrl(this, false));
     }
 
     private final class ReleaserDownloadUrl implements TemplateFunction {

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/release/BaseReleaser.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/release/BaseReleaser.java
@@ -272,9 +272,13 @@ public abstract class BaseReleaser<A extends org.jreleaser.model.api.release.Rel
         return resolveTemplate(latestReleaseUrl, props(model));
     }
 
-    public String getResolvedIssueTrackerUrl(JReleaserModel model) {
+    public String getResolvedIssueTrackerUrl(JReleaserModel model, boolean appendSlash) {
         if (!releaseSupported) return "";
-        return resolveTemplate(issueTrackerUrl, props(model));
+        String issueTracker = resolveTemplate(issueTrackerUrl, props(model));
+        if (appendSlash && isNotBlank(issueTracker) && !issueTracker.endsWith("/")) {
+            issueTracker += "/";
+        }
+        return issueTracker;
     }
 
     public boolean resolveUploadAssetsEnabled(Project project) {
@@ -771,7 +775,7 @@ public abstract class BaseReleaser<A extends org.jreleaser.model.api.release.Rel
         props.put(Constants.KEY_SRC_URL, getResolvedSrcUrl(model));
         props.put(Constants.KEY_RELEASE_NOTES_URL, getResolvedReleaseNotesUrl(model));
         props.put(Constants.KEY_LATEST_RELEASE_URL, getResolvedLatestReleaseUrl(model));
-        props.put(Constants.KEY_ISSUE_TRACKER_URL, getResolvedIssueTrackerUrl(model));
+        props.put(Constants.KEY_ISSUE_TRACKER_URL, getResolvedIssueTrackerUrl(model, false));
     }
 
     public static final class Update extends AbstractModelObject<Update> implements Domain, EnabledAware {

--- a/core/jreleaser-model-impl/src/main/resources/META-INF/jreleaser/changelog/preset-conventional-commits.yml
+++ b/core/jreleaser-model-impl/src/main/resources/META-INF/jreleaser/changelog/preset-conventional-commits.yml
@@ -81,4 +81,4 @@ categories:
     labels:
       - 'docs'
 
-format: '- {{commitShortHash}} {{#commitIsConventional}}{{#conventionalCommitIsBreakingChange}}🚨 {{/conventionalCommitIsBreakingChange}}{{#conventionalCommitScope}}**{{conventionalCommitScope}}**: {{/conventionalCommitScope}}{{conventionalCommitDescription}}{{#conventionalCommitBreakingChangeContent}} - *{{conventionalCommitBreakingChangeContent}}*{{/conventionalCommitBreakingChangeContent}}{{/commitIsConventional}}{{^commitIsConventional}}{{commitTitle}}{{/commitIsConventional}}'
+format: '- {{commitShortHash}} {{#commitIsConventional}}{{#conventionalCommitIsBreakingChange}}🚨 {{/conventionalCommitIsBreakingChange}}{{#conventionalCommitScope}}**{{conventionalCommitScope}}**: {{/conventionalCommitScope}}{{conventionalCommitDescription}}{{#conventionalCommitBreakingChangeContent}} - *{{conventionalCommitBreakingChangeContent}}*{{/conventionalCommitBreakingChangeContent}}{{/commitIsConventional}}{{^commitIsConventional}}{{commitTitle}}{{/commitIsConventional}}{{#commitHasIssues}}, closes{{#commitIssues}} {{issue}}{{/commitIssues}}{{/commitHasIssues}}'

--- a/sdks/jreleaser-git-java-sdk/src/main/java/org/jreleaser/sdk/git/ChangelogProvider.java
+++ b/sdks/jreleaser-git-java-sdk/src/main/java/org/jreleaser/sdk/git/ChangelogProvider.java
@@ -119,10 +119,7 @@ public class ChangelogProvider {
         context.getLogger().info(RB.$("issues.generator.extract"));
 
         BaseReleaser releaser = context.getModel().getRelease().getReleaser();
-        String issueTracker = releaser.getResolvedIssueTrackerUrl(context.getModel());
-        if (!issueTracker.endsWith("/")) {
-            issueTracker += "/";
-        }
+        String issueTracker = releaser.getResolvedIssueTrackerUrl(context.getModel(), true);
 
         String p1 = StringUtils.escapeRegexChars(issueTracker);
         String p2 = StringUtils.escapeRegexChars(releaser.getCanonicalRepoName());

--- a/sdks/jreleaser-git-java-sdk/src/main/java/org/jreleaser/sdk/git/ChangelogProvider.java
+++ b/sdks/jreleaser-git-java-sdk/src/main/java/org/jreleaser/sdk/git/ChangelogProvider.java
@@ -123,13 +123,16 @@ public class ChangelogProvider {
 
         String p1 = StringUtils.escapeRegexChars(issueTracker);
         String p2 = StringUtils.escapeRegexChars(releaser.getCanonicalRepoName());
-        Pattern pattern = Pattern.compile(".*" + p1 + "(\\d+)|.*" + p2 + "#(\\d+)|.*#(\\d+)" + ".*");
+        String p3 = StringUtils.escapeRegexChars(releaser.getName());
+        String regex = "(?:" + p2 + "|(?<!/)" + p3 + ")#(?<repo>\\d+)|[^a-zA-Z0-9]#(?<hash>\\d+)";
+        regex += isNotBlank(p1) ? "|" + p1 + "(?<tracker>\\d+)" : "";
+        Pattern pattern = Pattern.compile(regex);
         Matcher matcher = pattern.matcher(content);
         Set<Integer> issues = new TreeSet<>();
         while (matcher.find()) {
-            if (isNotBlank(matcher.group(1))) issues.add(Integer.valueOf(matcher.group(1)));
-            if (isNotBlank(matcher.group(2))) issues.add(Integer.valueOf(matcher.group(2)));
-            if (isNotBlank(matcher.group(3))) issues.add(Integer.valueOf(matcher.group(3)));
+            if (isNotBlank(matcher.group("repo"))) issues.add(Integer.valueOf(matcher.group("repo")));
+            if (isNotBlank(matcher.group("hash"))) issues.add(Integer.valueOf(matcher.group("hash")));
+            if (isNotBlank(p1) && isNotBlank(matcher.group("tracker"))) issues.add(Integer.valueOf(matcher.group("tracker")));
         }
 
         return issues;

--- a/sdks/jreleaser-git-java-sdk/src/test/java/org/jreleaser/sdk/git/ChangelogGeneratorUnitTest.java
+++ b/sdks/jreleaser-git-java-sdk/src/test/java/org/jreleaser/sdk/git/ChangelogGeneratorUnitTest.java
@@ -294,7 +294,7 @@ public class ChangelogGeneratorUnitTest {
         when(mockGitSdk.open()).thenReturn(git);
 
         ChangelogGenerator.Commit commit = mock(ChangelogGenerator.Commit.class);
-        when(commit.asContext(anyBoolean(), any())).thenReturn(new HashMap<>());
+        when(commit.asContext(anyBoolean(), any(), any())).thenReturn(new HashMap<>());
         commitMockedStatic.when(() -> ChangelogGenerator.Commit.of(any())).thenReturn(commit);
 
         Mockito.doReturn(true).when(changelogGenerator).checkLabels(commit, changelog);

--- a/sdks/jreleaser-git-java-sdk/src/test/java/org/jreleaser/sdk/git/CommitUnitTest.java
+++ b/sdks/jreleaser-git-java-sdk/src/test/java/org/jreleaser/sdk/git/CommitUnitTest.java
@@ -1,0 +1,196 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2022 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.sdk.git;
+
+import org.eclipse.jgit.lib.AbbreviatedObjectId;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.jreleaser.logging.JReleaserLogger;
+import org.jreleaser.model.internal.JReleaserContext;
+import org.jreleaser.model.internal.JReleaserModel;
+import org.jreleaser.model.internal.release.BaseReleaser;
+import org.jreleaser.model.internal.release.Changelog;
+import org.jreleaser.model.internal.release.Release;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jreleaser.util.StringUtils.isNotBlank;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CommitUnitTest {
+
+    private final JReleaserContext defaultContext = mockContext("", "repo", "");
+
+    private JReleaserContext mockContext(String issueTracker, String repo, String owner) {
+        JReleaserContext context = mock(JReleaserContext.class);
+        JReleaserLogger logger = mock(JReleaserLogger.class);
+        JReleaserModel model = mock(JReleaserModel.class);
+        Release release = mock(Release.class);
+        BaseReleaser releaser = mock(BaseReleaser.class);
+
+        when(context.getLogger()).thenReturn(logger);
+        when(context.getModel()).thenReturn(model);
+        when(model.getRelease()).thenReturn(release);
+        when(release.getReleaser()).thenReturn(releaser);
+        when(releaser.getResolvedIssueTrackerUrl(any(), anyBoolean())).thenReturn(issueTracker);
+        when(releaser.getCanonicalRepoName()).thenReturn(isNotBlank(owner) ? owner + "/" + repo : repo);
+        when(releaser.getName()).thenReturn(repo);
+
+        return context;
+    }
+
+    private ChangelogGenerator.Commit mockCommit(String commitBody) {
+        RevCommit revCommit = mock(RevCommit.class);
+        ObjectId objectId = mock(ObjectId.class);
+        AbbreviatedObjectId abbreviatedObjectId = mock(AbbreviatedObjectId.class);
+        PersonIdent committer = mock(PersonIdent.class);
+        PersonIdent author = mock(PersonIdent.class);
+        Changelog changelog = mock(Changelog.class);
+        int time = 123456;
+
+        when(revCommit.getId()).thenReturn(objectId);
+        when(objectId.name()).thenReturn("full-hash");
+        when(objectId.abbreviate(7)).thenReturn(abbreviatedObjectId);
+        when(abbreviatedObjectId.name()).thenReturn("short-hash");
+        when(revCommit.getFullMessage()).thenReturn(commitBody);
+        when(revCommit.getCommitterIdent()).thenReturn(committer);
+        when(committer.getName()).thenReturn("committer-name");
+        when(committer.getEmailAddress()).thenReturn("committer@example.com");
+        when(revCommit.getAuthorIdent()).thenReturn(author);
+        when(author.getName()).thenReturn("author-name");
+        when(author.getEmailAddress()).thenReturn("author@example.com");
+        when(revCommit.getCommitTime()).thenReturn(time);
+        when(changelog.getPreset()).thenReturn("conventional-commits");
+
+        return ChangelogGenerator.Commit.of(revCommit);
+    }
+
+    @Test
+    public void closeFooterWithHash() {
+        String commitBody = "feat(scope): add new feature\n" +
+            "\n" +
+            "BREAKING CHANGE: single line breaking change\n" +
+            "Reviewed-by: Z\n" +
+            "Closes #42";
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody).extractIssues(defaultContext);
+
+        assertThat(c.issues)
+            .hasSize(1)
+            .containsExactlyInAnyOrder(42);
+    }
+
+    @Test
+    public void refsFooterWithDotsAndHash() {
+        String commitBody = "fix: prevent racing of requests\n" +
+            "\n" +
+            "Introduce a request id and a reference to latest request. Dismiss\n" +
+            "incoming responses other than from latest request.\n" +
+            "\n" +
+            "Remove timeouts which were used to mitigate the racing issue but are\n" +
+            "obsolete now.\n" +
+            "\n" +
+            "Reviewed-by: Z\n" +
+            "Refs: #123";
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody).extractIssues(defaultContext);
+
+        assertThat(c.issues)
+            .hasSize(1)
+            .containsExactlyInAnyOrder(123);
+    }
+
+    @Test
+    public void multipleHashes() {
+        String commitBody = "a classic commit that fixes #46 (#47)";
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody).extractIssues(defaultContext);
+
+        assertThat(c.issues)
+            .hasSize(2)
+            .containsExactlyInAnyOrder(46, 47);
+    }
+
+    @Test
+    public void multipleHashes2() {
+        String commitBody = "a classic commit\n" +
+            "Closes: #1, #2, #3";
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody).extractIssues(defaultContext);
+
+        assertThat(c.issues)
+            .hasSize(3)
+            .containsExactlyInAnyOrder(1, 2, 3);
+    }
+
+    @Test
+    public void issueTracker() {
+        String commitBody = "a classic commit\n" +
+            "Closes: https://github.com/owner/repo/issues/1, https://github.com/owner/repo/issues/2, #3";
+
+        JReleaserContext context = mockContext("https://github.com/owner/repo/issues/", "repo", "");
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody).extractIssues(context);
+
+        assertThat(c.issues)
+            .hasSize(3)
+            .containsExactlyInAnyOrder(1, 2, 3);
+    }
+
+    @Test
+    public void repoOnly() {
+        String commitBody = "a classic commit\n" +
+            "#1, repo#2, other#3";
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody).extractIssues(defaultContext);
+
+        assertThat(c.issues)
+            .hasSize(2)
+            .containsExactlyInAnyOrder(1, 2);
+    }
+
+    @Test
+    public void repoWithOwner() {
+        String commitBody = "a classic commit\n" +
+            "Closes: someone/repo#1, owner/repo#2, repo#3, (#4)";
+
+        JReleaserContext context = mockContext("", "repo", "owner");
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody).extractIssues(context);
+
+        assertThat(c.issues)
+            .hasSize(3)
+            .containsExactlyInAnyOrder(2, 3, 4);
+    }
+
+    @Test
+    public void otherNumbers() {
+        String commitBody = "upgrade SQLite to 3.40.0\n" +
+            "previously log() computed the natural logarithm, now it computes a base-10 logarithm";
+
+        JReleaserContext context = mockContext("https://github.com/owner/repo/issues/", "repo", "");
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody).extractIssues(context);
+
+        assertThat(c.issues).isEmpty();
+    }
+}

--- a/sdks/jreleaser-git-java-sdk/src/test/java/org/jreleaser/sdk/git/ConventionalCommitUnitTest.java
+++ b/sdks/jreleaser-git-java-sdk/src/test/java/org/jreleaser/sdk/git/ConventionalCommitUnitTest.java
@@ -249,7 +249,7 @@ public class ConventionalCommitUnitTest {
             .hasFieldOrPropertyWithValue("ccBody", "");
         assertThat(((ChangelogGenerator.ConventionalCommit) c).getTrailers()).isEmpty();
 
-        assertThat(c.asContext(false, ""))
+        assertThat(c.asContext(false, "", ""))
             .containsEntry("commitIsConventional", true)
             .containsEntry("conventionalCommitBreakingChangeContent", "")
             .containsEntry("conventionalCommitIsBreakingChange", true)
@@ -277,7 +277,7 @@ public class ConventionalCommitUnitTest {
             .hasFieldOrPropertyWithValue("ccBody", "");
         assertThat(((ChangelogGenerator.ConventionalCommit) c).getTrailers()).isEmpty();
 
-        assertThat(c.asContext(false, ""))
+        assertThat(c.asContext(false, "", ""))
             .containsEntry("commitIsConventional", true)
             .containsEntry("conventionalCommitBreakingChangeContent", "!!use JavaScript features not available in Node 6.!!")
             .containsEntry("conventionalCommitIsBreakingChange", true)


### PR DESCRIPTION
Fixes #806

I reused the `ChangelogProvider.extractIssues` method so that what's displayed in the changelog is the same as the issues that are commented upon to advise they have been released.

I have placed the logic inside the `Commit` class, since it can apply to any type of commit, not just conventional ones.
I could not find a Mustache way to display something once if a list is not empty, so i added a `commitIssuesCount` property. If you know how to do so, we could get rid of that extra property, however everything i tried didn't work.

Couple of things you may want to double-check:
- i have modified the default format of the conventional-commits preset
- i have **not** modified the default format
- since there is an info log in `extractIssues`, it is logged once for each commit, and may confuse the user as to why the same log line is repeated many times
- the issues in the Mustache context are always prefixed by `#`. This is done so that pre-computed links look better, and to ensure links that would be rendered by Github or others would always be rendered as links, so the `#` doesn't need to be added in the template. It may be a bit restrictive, but i think that should be fine with most users.

The PR is separated in multiple commits, as some are fixes that are required but not directly related to the new feature. Feel free to keep as-is, or squash when merging. I thought you would appreciate the split, even just to see them separately.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
