### PR TITLE
fix: Small static analysis findings

### DIFF
--- a/api/jreleaser-logger-api/src/main/java/org/jreleaser/logging/AbstractJReleaserLogger.java
+++ b/api/jreleaser-logger-api/src/main/java/org/jreleaser/logging/AbstractJReleaserLogger.java
@@ -34,7 +34,7 @@ public abstract class AbstractJReleaserLogger implements JReleaserLogger {
     }
 
     protected boolean isIndented() {
-        return !indent.equals("");
+        return !"".equals(indent);
     }
 
     @Override

--- a/api/jreleaser-model-api/src/main/java/org/jreleaser/version/SemanticVersion.java
+++ b/api/jreleaser-model-api/src/main/java/org/jreleaser/version/SemanticVersion.java
@@ -54,7 +54,7 @@ public class SemanticVersion implements Version<SemanticVersion> {
         this.pattern = pattern;
 
         if (isNotBlank(tagsep)) {
-            requireState(tagsep.equals(".") || tagsep.equals("-"), "Argument 'tagsep' must not be '.' or '-'");
+            requireState(".".equals(tagsep) || "-".equals(tagsep), "Argument 'tagsep' must not be '.' or '-'");
         }
     }
 

--- a/api/jreleaser-utils/src/main/java/org/jreleaser/util/CollectionUtils.java
+++ b/api/jreleaser-utils/src/main/java/org/jreleaser/util/CollectionUtils.java
@@ -181,7 +181,7 @@ public final class CollectionUtils {
     }
 
     public static <K, V> MapBuilder<K, V> map() {
-        return map(new LinkedHashMap<K, V>());
+        return map(new LinkedHashMap<>());
     }
 
     public static <K, V> MapBuilder<K, V> map(Map<K, V> delegate) {
@@ -189,7 +189,7 @@ public final class CollectionUtils {
     }
 
     public static <E> ListBuilder<E> list() {
-        return list(new ArrayList<E>());
+        return list(new ArrayList<>());
     }
 
     public static <E> ListBuilder<E> list(List<E> delegate) {
@@ -197,7 +197,7 @@ public final class CollectionUtils {
     }
 
     public static <E> SetBuilder<E> set() {
-        return set(new HashSet<E>());
+        return set(new HashSet<>());
     }
 
     public static <E> SetBuilder<E> set(Set<E> delegate) {

--- a/api/jreleaser-utils/src/test/java/org/jreleaser/util/CollectionUtilsTest.java
+++ b/api/jreleaser-utils/src/test/java/org/jreleaser/util/CollectionUtilsTest.java
@@ -145,7 +145,7 @@ class CollectionUtilsTest {
         map1.put("key.string", "string");
         map1.put("key.boolean", true);
         map1.put("key.list", asList(1, 2, 3));
-        LinkedHashMap<String, Integer> map2 = new LinkedHashMap<String, Integer>(2);
+        LinkedHashMap<String, Integer> map2 = new LinkedHashMap<>(2);
         map2.put("one", 1);
         map2.put("two", 2);
         map1.put("key.map", map2);

--- a/core/jreleaser-engine/src/main/java/org/jreleaser/assemblers/JpackageAssemblerProcessor.java
+++ b/core/jreleaser-engine/src/main/java/org/jreleaser/assemblers/JpackageAssemblerProcessor.java
@@ -141,7 +141,7 @@ public class JpackageAssemblerProcessor extends AbstractJavaAssemblerProcessor<o
 
         try {
             if (!FileUtils.copyFilesRecursive(context.getLogger(), originalImage, adjustedImage, path -> {
-                boolean pathIsJar = path.getFileName().toString().endsWith(".jar") && "jars".equals(path.getParent().getFileName().toString());
+                boolean pathIsJar = path.getFileName().toString().endsWith(".jar") && path.getParent().getFileName().toString().equals("jars");
                 boolean pathIsExecutable = path.getFileName().toString().equals(context.getModel().getAssemble().findJlink(assembler.getJlink()).getExecutable());
                 return pathIsJar || pathIsExecutable;
             })) {

--- a/core/jreleaser-engine/src/main/java/org/jreleaser/assemblers/JpackageAssemblerProcessor.java
+++ b/core/jreleaser-engine/src/main/java/org/jreleaser/assemblers/JpackageAssemblerProcessor.java
@@ -141,7 +141,7 @@ public class JpackageAssemblerProcessor extends AbstractJavaAssemblerProcessor<o
 
         try {
             if (!FileUtils.copyFilesRecursive(context.getLogger(), originalImage, adjustedImage, path -> {
-                boolean pathIsJar = path.getFileName().toString().endsWith(".jar") && path.getParent().getFileName().toString().equals("jars");
+                boolean pathIsJar = path.getFileName().toString().endsWith(".jar") && "jars".equals(path.getParent().getFileName().toString());
                 boolean pathIsExecutable = path.getFileName().toString().equals(context.getModel().getAssemble().findJlink(assembler.getJlink()).getExecutable());
                 return pathIsJar || pathIsExecutable;
             })) {

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/KordampJReleaserAdapter.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/KordampJReleaserAdapter.groovy
@@ -48,7 +48,7 @@ class KordampJReleaserAdapter {
         }
         if (!jreleaser.project.license.present) {
             List<License> licenses = config.licensing.allLicenses()
-            if (licenses.size() > 0) {
+            if (!licenses.isEmpty()) {
                 License license = licenses.find {
                     it.primary
                 } ?: licenses[0]

--- a/sdks/jreleaser-codeberg-java-sdk/src/main/java/org/jreleaser/sdk/codeberg/CodebergReleaser.java
+++ b/sdks/jreleaser-codeberg-java-sdk/src/main/java/org/jreleaser/sdk/codeberg/CodebergReleaser.java
@@ -351,7 +351,7 @@ public class CodebergReleaser extends AbstractReleaser<org.jreleaser.model.api.r
             if (!op.isPresent()) continue;
 
             GtIssue gtIssue = op.get();
-            if (gtIssue.getState().equals("closed") && gtIssue.getLabels().stream().noneMatch(l -> l.getName().equals(labelName))) {
+            if ("closed".equals(gtIssue.getState()) && gtIssue.getLabels().stream().noneMatch(l -> l.getName().equals(labelName))) {
                 context.getLogger().debug(RB.$("git.issue.release", issueNumber));
                 api.addLabelToIssue(codeberg.getOwner(), codeberg.getName(), gtIssue, gtLabel);
                 api.commentOnIssue(codeberg.getOwner(), codeberg.getName(), gtIssue, comment);

--- a/sdks/jreleaser-git-java-sdk/src/main/java/org/jreleaser/sdk/git/ChangelogGenerator.java
+++ b/sdks/jreleaser-git-java-sdk/src/main/java/org/jreleaser/sdk/git/ChangelogGenerator.java
@@ -682,7 +682,7 @@ public class ChangelogGenerator {
             }
 
             // drop any empty lines at the beginning
-            while (!lines.isEmpty() && lines.get(0).equals("")) {
+            while (!lines.isEmpty() && "".equals(lines.get(0))) {
                 lines.remove(0);
             }
 
@@ -691,7 +691,7 @@ public class ChangelogGenerator {
                 Matcher matcherTrailer = TRAILER_PATTERN.matcher(lines.get(lines.size() - 1));
                 if (matcherTrailer.matches()) {
                     String token = matcherTrailer.group("token");
-                    if (token.equals("BREAKING-CHANGE")) break;
+                    if ("BREAKING-CHANGE".equals(token)) break;
                     trailers.add(new Trailer(token, matcherTrailer.group("value")));
                     lines.remove(lines.size() - 1); // consume last line
                 } else {
@@ -700,7 +700,7 @@ public class ChangelogGenerator {
             }
 
             // drop any empty lines at the end
-            while (!lines.isEmpty() && lines.get(lines.size() - 1).equals("")) {
+            while (!lines.isEmpty() && "".equals(lines.get(lines.size() - 1))) {
                 lines.remove(lines.size() - 1);
             }
 

--- a/sdks/jreleaser-gitea-java-sdk/src/main/java/org/jreleaser/sdk/gitea/GiteaReleaser.java
+++ b/sdks/jreleaser-gitea-java-sdk/src/main/java/org/jreleaser/sdk/gitea/GiteaReleaser.java
@@ -350,7 +350,7 @@ public class GiteaReleaser extends AbstractReleaser<org.jreleaser.model.api.rele
             if (!op.isPresent()) continue;
 
             GtIssue gtIssue = op.get();
-            if (gtIssue.getState().equals("closed") && gtIssue.getLabels().stream().noneMatch(l -> l.getName().equals(labelName))) {
+            if ("closed".equals(gtIssue.getState()) && gtIssue.getLabels().stream().noneMatch(l -> l.getName().equals(labelName))) {
                 context.getLogger().debug(RB.$("git.issue.release", issueNumber));
                 api.addLabelToIssue(gitea.getOwner(), gitea.getName(), gtIssue, gtLabel);
                 api.commentOnIssue(gitea.getOwner(), gitea.getName(), gtIssue, comment);

--- a/sdks/jreleaser-gitlab-java-sdk/src/main/java/org/jreleaser/sdk/gitlab/GitlabReleaser.java
+++ b/sdks/jreleaser-gitlab-java-sdk/src/main/java/org/jreleaser/sdk/gitlab/GitlabReleaser.java
@@ -441,7 +441,7 @@ public class GitlabReleaser extends AbstractReleaser<org.jreleaser.model.api.rel
             if (!op.isPresent()) continue;
 
             GlIssue glIssue = op.get();
-            if (glIssue.getState().equals("closed") && glIssue.getLabels().stream().noneMatch(l -> l.equals(labelName))) {
+            if ("closed".equals(glIssue.getState()) && glIssue.getLabels().stream().noneMatch(l -> l.equals(labelName))) {
                 context.getLogger().debug(RB.$("git.issue.release", issueNumber));
                 api.addLabelToIssue(projectIdentifier, glIssue, glLabel);
                 api.commentOnIssue(projectIdentifier, glIssue, comment);

--- a/sdks/jreleaser-webhooks-java-sdk/src/main/java/org/jreleaser/sdk/webhooks/WebhooksAnnouncer.java
+++ b/sdks/jreleaser-webhooks-java-sdk/src/main/java/org/jreleaser/sdk/webhooks/WebhooksAnnouncer.java
@@ -90,7 +90,7 @@ public class WebhooksAnnouncer implements Announcer<org.jreleaser.model.api.anno
             message = webhook.getResolvedMessage(context);
         } else {
             TemplateContext props = new TemplateContext();
-            if (webhook.getName().equals("teams")) {
+            if ("teams".equals(webhook.getName())) {
                 props.set(Constants.KEY_CHANGELOG, passThrough(convertLineEndings(context.getChangelog().getResolvedChangelog())));
                 props.set(Constants.KEY_CHANGELOG_CHANGES, passThrough(convertLineEndings(context.getChangelog().getFormattedChanges())));
                 props.set(Constants.KEY_CHANGELOG_CONTRIBUTORS, passThrough(convertLineEndings(context.getChangelog().getFormattedContributors())));


### PR DESCRIPTION
### Context
Hi! Saw you recently added Sonar and wanted to reduce the number of findings; figured I'd see if I could help with a few automated fixes; hope it's appreciated.

I chose to run only a select few recipes, as these had a manageable changeset and hopefully desirable outcomes. Here's a log of what changes were made where.

```
Changes have been made to plugins/jdks-maven-plugin/build/mavenPlugin/helpMojo/org/jreleaser/jdks/maven/plugin/help/HelpMojo.java by:
    org.openrewrite.java.cleanup.UseDiamondOperator
Changes have been made to sdks/jreleaser-codeberg-java-sdk/src/main/java/org/jreleaser/sdk/codeberg/CodebergReleaser.java by:
    org.openrewrite.java.cleanup.EqualsAvoidsNull
Changes have been made to core/jreleaser-engine/src/main/java/org/jreleaser/assemblers/JpackageAssemblerProcessor.java by:
    org.openrewrite.java.cleanup.EqualsAvoidsNull
Changes have been made to sdks/jreleaser-git-java-sdk/src/main/java/org/jreleaser/sdk/git/ChangelogGenerator.java by:
    org.openrewrite.java.cleanup.EqualsAvoidsNull
Changes have been made to sdks/jreleaser-gitea-java-sdk/src/main/java/org/jreleaser/sdk/gitea/GiteaReleaser.java by:
    org.openrewrite.java.cleanup.EqualsAvoidsNull
Changes have been made to sdks/jreleaser-gitlab-java-sdk/src/main/java/org/jreleaser/sdk/gitlab/GitlabReleaser.java by:
    org.openrewrite.java.cleanup.EqualsAvoidsNull
Changes have been made to plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/KordampJReleaserAdapter.groovy by:
    org.openrewrite.java.cleanup.IsEmptyCallOnCollections
Changes have been made to api/jreleaser-logger-api/src/main/java/org/jreleaser/logging/AbstractJReleaserLogger.java by:
    org.openrewrite.java.cleanup.EqualsAvoidsNull
Changes have been made to plugins/jreleaser-maven-plugin/build/mavenPlugin/helpMojo/org/jreleaser/maven/plugin/help/HelpMojo.java by:
    org.openrewrite.java.cleanup.UseDiamondOperator
Changes have been made to api/jreleaser-model-api/src/main/java/org/jreleaser/version/SemanticVersion.java by:
    org.openrewrite.java.cleanup.EqualsAvoidsNull
Changes have been made to api/jreleaser-utils/src/main/java/org/jreleaser/util/CollectionUtils.java by:
    org.openrewrite.java.cleanup.UseDiamondOperator
Changes have been made to api/jreleaser-utils/src/test/java/org/jreleaser/util/CollectionUtilsTest.java by:
    org.openrewrite.java.cleanup.UseDiamondOperator
Changes have been made to sdks/jreleaser-webhooks-java-sdk/src/main/java/org/jreleaser/sdk/webhooks/WebhooksAnnouncer.java by:
    org.openrewrite.java.cleanup.EqualsAvoidsNull
```

If needed I can recreate these changes excluding for instance the `EqualsAvoidsNull` if that does not fit the desired code style.

As these changes were mostly automated I'm not particularly attached to them, so if you feel it does not improve the project feel free to not accept the contribution; no harmed feelings. :)

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
