### PR TITLE
fix: default to unversioned jdk dependency in brew (#1224)

### DIFF
--- a/api/jreleaser-utils/src/main/java/org/jreleaser/util/StringUtils.java
+++ b/api/jreleaser-utils/src/main/java/org/jreleaser/util/StringUtils.java
@@ -703,10 +703,14 @@ public final class StringUtils {
         return Pattern.compile(toSafeRegexPattern(str));
     }
 
-    public static boolean isTrue(Object o) {
-        if (null == o) return false;
+    public static boolean isTrue(Object o, boolean defaultIfAbsent) {
+        if (null == o) return defaultIfAbsent;
         if (o instanceof Boolean) return (Boolean) o;
         return "true".equalsIgnoreCase(String.valueOf(o).trim());
+    }
+
+    public static boolean isTrue(Object o) {
+        return isTrue(o, false);
     }
 
     public static boolean isFalse(Object o) {

--- a/api/jreleaser-utils/src/test/java/org/jreleaser/util/StringUtilsTest.java
+++ b/api/jreleaser-utils/src/test/java/org/jreleaser/util/StringUtilsTest.java
@@ -178,5 +178,17 @@ class StringUtilsTest {
     void testGetClassNameForLowerCaseHyphenSeparatedName() {
         assertEquals("StringUtils", StringUtils.getClassNameForLowerCaseHyphenSeparatedName("string-utils"));
     }
+
+    @Test
+    void testPropertyConversion() {
+        assertFalse(StringUtils.isTrue(null));
+        assertFalse(StringUtils.isTrue(null, false));
+        assertTrue(StringUtils.isTrue(null, true));
+
+        assertTrue(StringUtils.isTrue("true"));
+        assertTrue(StringUtils.isTrue("tRuE"));
+
+        assertFalse(StringUtils.isTrue(""));
+    }
 }
 


### PR DESCRIPTION
Fixes jreleaser/jreleaser#1224

### Context
See jreleaser/jreleaser#1224 . Automatic JRE/JDK ("openjdk" or "java") dependency without a version is only added if there isn't one already.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
