### PR TITLE
Draft: Adding FeignLogger that wraps JReleaserLogger

### DIFF
--- a/sdks/jreleaser-java-sdk-commons/src/main/java/org/jreleaser/sdk/commons/ClientUtils.java
+++ b/sdks/jreleaser-java-sdk-commons/src/main/java/org/jreleaser/sdk/commons/ClientUtils.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.Client;
 import feign.Feign;
+import feign.Logger;
 import feign.Request;
 import feign.form.FormData;
 import feign.form.FormEncoder;
@@ -36,6 +37,7 @@ import org.jreleaser.model.JReleaserVersion;
 import org.jreleaser.model.internal.JReleaserModelPrinter;
 import org.jreleaser.model.spi.announce.AnnounceException;
 import org.jreleaser.model.spi.upload.UploadException;
+import org.jreleaser.sdk.commons.feign.FeignLogger;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
@@ -107,6 +109,8 @@ public final class ClientUtils {
         }
 
         return builder
+            .logger(new FeignLogger(logger))
+            .logLevel(Logger.Level.FULL)
             .encoder(new FormEncoder(new JacksonEncoder()))
             .decoder(new JacksonDecoder())
             .requestInterceptor(template -> template.header("User-Agent", "JReleaser/" + JReleaserVersion.getPlainVersion()))

--- a/sdks/jreleaser-java-sdk-commons/src/main/java/org/jreleaser/sdk/commons/feign/FeignLogger.java
+++ b/sdks/jreleaser-java-sdk-commons/src/main/java/org/jreleaser/sdk/commons/feign/FeignLogger.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2023 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.sdk.commons.feign;
+
+import org.jreleaser.logging.JReleaserLogger;
+
+public class FeignLogger extends feign.Logger {
+
+    private final JReleaserLogger logger;
+
+    public FeignLogger(JReleaserLogger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    protected void log(String configKey, String format, Object... args) {
+        logger.debug(String.format(methodTag(configKey) + format, args));
+    }
+}


### PR DESCRIPTION
Sets the log level to full (wire logging), but will only output if JReleaser logger debug level is enabled

<!-- The issue this PR addresses -->
<!-- Please reference the issue this PR solves -->
Fixes #?

### Context
<!-- What problem does this change address? -->
<!-- Link to relevant issues or discussions here -->

I was trying to figure out why GitHub username was not getting resolved but didn't know what the API was returning. I had to add a feign logger to do so.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
