### PR TITLE
fix(changelog): conventional commit scope should allow more characters

### DIFF
--- a/sdks/jreleaser-git-java-sdk/src/main/java/org/jreleaser/sdk/git/ChangelogGenerator.java
+++ b/sdks/jreleaser-git-java-sdk/src/main/java/org/jreleaser/sdk/git/ChangelogGenerator.java
@@ -700,7 +700,7 @@ public class ChangelogGenerator {
 
     static class ConventionalCommit extends Commit {
         private static final Pattern FIRST_LINE_PATTERN =
-            Pattern.compile("^(?<type>\\w+)(?:\\((?<scope>\\w+)\\))?(?<bang>!)?: (?<description>.*$)");
+            Pattern.compile("^(?<type>\\w+)(?:\\((?<scope>[^)\\n]+)\\))?(?<bang>!)?: (?<description>.*$)");
         private static final Pattern BREAKING_CHANGE_PATTERN = Pattern.compile("^BREAKING[ \\-]CHANGE:\\s+(?<content>[\\w\\W]+)", Pattern.MULTILINE);
         private static final Pattern TRAILER_PATTERN = Pattern.compile("(?<token>^\\w+(?:-\\w+)*)(?:: | #)(?<value>.*$)");
 

--- a/sdks/jreleaser-git-java-sdk/src/test/java/org/jreleaser/sdk/git/ConventionalCommitUnitTest.java
+++ b/sdks/jreleaser-git-java-sdk/src/test/java/org/jreleaser/sdk/git/ConventionalCommitUnitTest.java
@@ -214,6 +214,40 @@ class ConventionalCommitUnitTest {
     }
 
     @Test
+    void scopeCanHaveDash() {
+        String commitBody = "build(deps-dev): bump mockito-core from 4.8.1 to 5.2.0";
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody);
+
+        assertThat(c)
+            .hasFieldOrPropertyWithValue("isConventional", true)
+            .hasFieldOrPropertyWithValue("ccIsBreakingChange", false)
+            .hasFieldOrPropertyWithValue("ccBreakingChangeContent", "")
+            .hasFieldOrPropertyWithValue("ccType", "build")
+            .hasFieldOrPropertyWithValue("ccScope", "deps-dev")
+            .hasFieldOrPropertyWithValue("ccDescription", "bump mockito-core from 4.8.1 to 5.2.0")
+            .hasFieldOrPropertyWithValue("ccBody", "");
+        assertThat(((ChangelogGenerator.ConventionalCommit) c).getTrailers()).isEmpty();
+    }
+
+    @Test
+    void scopeCanHaveOtherCharacters() {
+        String commitBody = "build(@scope/pkg-name): javascript style scope";
+
+        ChangelogGenerator.Commit c = mockCommit(commitBody);
+
+        assertThat(c)
+            .hasFieldOrPropertyWithValue("isConventional", true)
+            .hasFieldOrPropertyWithValue("ccIsBreakingChange", false)
+            .hasFieldOrPropertyWithValue("ccBreakingChangeContent", "")
+            .hasFieldOrPropertyWithValue("ccType", "build")
+            .hasFieldOrPropertyWithValue("ccScope", "@scope/pkg-name")
+            .hasFieldOrPropertyWithValue("ccDescription", "javascript style scope")
+            .hasFieldOrPropertyWithValue("ccBody", "");
+        assertThat(((ChangelogGenerator.ConventionalCommit) c).getTrailers()).isEmpty();
+    }
+
+    @Test
     void ccExample1() {
         String commitBody = "feat: allow provided config object to extend other configs\n" +
             "\n" +


### PR DESCRIPTION
Taken from the grammar published in https://github.com/conventional-commits/parser#the-grammar

Refs: https://github.com/conventional-commits/conventionalcommits.org/issues/223

I noticed the issue with dependabot commits of the form: `build(deps-dev): bump mockito-core from 4.8.1 to 5.2.0` which were not properly categorized as conventional.


### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
