### PR TITLE
fix(assemble): launchers should work without JAVA_HOME if java is found

### DIFF
--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/java-archive/java-archive/bin/launcher.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/java-archive/java-archive/bin/launcher.tpl
@@ -77,7 +77,6 @@ Please set the JAVA_HOME variable in your environment to match the
 location of your Java installation."
 fi
 
-JAVACMD="$JAVA_HOME/bin/java"
 JARSDIR="$APP_HOME/lib"
 {{#distributionJavaMainModule}}
 CLASSPATH="$JARSDIR"

--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/single-jar/appimage/launcher.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/single-jar/appimage/launcher.tpl
@@ -36,8 +36,6 @@ Please set the JAVA_HOME variable in your environment to match the
 location of your Java installation."
 fi
 
-JAVACMD="$JAVA_HOME/bin/java"
-
 # Collect all arguments for the java command;
 #   * $JAVA_OPTS can contain fragments of
 #     shell script including quotes and variable substitutions, so put them in


### PR DESCRIPTION
Resolves #1284. As far as I can see, the same pattern isn't used anywhere else except in the jlink templates where it should be correct. The Windows .bat launchers look OK too (not tested, but there's a goto that skips to the right place).

<!-- The issue this PR addresses -->
<!-- Please reference the issue this PR solves -->
Fixes #1284.

### Context

If no JAVA_HOME is found but a java executable is on the PATH (checked using which), the script should go ahead using that instead of relying on JAVA_HOME.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
