### PR TITLE
fix(chronver): Fix chronver version_parsing regex 

### DIFF
--- a/api/jreleaser-model-api/src/main/java/org/jreleaser/version/ChronVer.java
+++ b/api/jreleaser-model-api/src/main/java/org/jreleaser/version/ChronVer.java
@@ -34,7 +34,7 @@ import static org.jreleaser.util.StringUtils.requireNonBlank;
  * @since 1.0.0
  */
 public class ChronVer implements Version<ChronVer> {
-    private static final Pattern VERSION_PATTERN = Pattern.compile("^([2-9]\\d{3})\\.(0[1-9]|1[0-2])\\.(0[1-9]|[1-2]\\d|3[0-1])(?:\\.((?:[1-9]\\d*)(?:(?:-[a-zA-Z0-9]+)+(?:\\.[1-9]\\d*)?)?))?$");
+    private static final Pattern VERSION_PATTERN = Pattern.compile("^([2-9]\\d{3})\\.(0[1-9]|1[0-2])\\.(0[1-9]|[1-2]\\d|3[0-1])(?:\\.((?:[1-9]\\d*)(?:(?:-[a-zA-Z0-9]+)+(?:\\.[1-9]\\d*)?)?))?(?:-[a-zA-Z0-9]+)?$");
     private static final Pattern CHANGESET_PATTERN = Pattern.compile("^(?:((?:[1-9]\\d*))(?:-([a-zA-Z0-9-]+[a-zA-Z0-9]?)(?:\\.([1-9]\\d*))?)?)?$");
 
     private final int year;

--- a/api/jreleaser-model-api/src/test/java/org/jreleaser/version/ChronVerTest.java
+++ b/api/jreleaser-model-api/src/test/java/org/jreleaser/version/ChronVerTest.java
@@ -83,7 +83,8 @@ class ChronVerTest {
             Arguments.of("2022.01.02", 2022, 1, 2, null, 0, null, 0),
             Arguments.of("2022.01.02.1", 2022, 1, 2, "1", 1, null, 0),
             Arguments.of("2022.01.02.1-break", 2022, 1, 2, "1-break", 1, "break", 0),
-            Arguments.of("2022.01.02.1-break.2", 2022, 1, 2, "1-break.2", 1, "break", 2)
+            Arguments.of("2022.01.02.1-break.2", 2022, 1, 2, "1-break.2", 1, "break", 2),
+            Arguments.of("2022.01.02-tag", 2022, 1, 2, null, 0, "tag", 0)
         );
     }
 


### PR DESCRIPTION
<!-- The issue this PR addresses -->
<!-- Please reference the issue this PR solves -->
Fixes #1295 

### Context
<!-- What problem does this change address? -->
Allows chronver release versions like '2023.03.26-latest' 
<!-- Link to relevant issues or discussions here -->

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
