### PR TITLE
feat(release): support bitbucket cloud releases

### DIFF
--- a/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/release/BitbucketcloudReleaser.java
+++ b/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/release/BitbucketcloudReleaser.java
@@ -17,23 +17,10 @@
  */
 package org.jreleaser.model.api.release;
 
-import org.jreleaser.model.api.common.Domain;
-
 /**
- * @author Andres Almiray
- * @since 0.1.0
+ * @author Hasnae Rehioui
+ * @since 1.7.0
  */
-public interface Release extends Domain {
-    BitbucketcloudReleaser getBitbucketcloud();
-    GithubReleaser getGithub();
-
-    GitlabReleaser getGitlab();
-
-    GiteaReleaser getGitea();
-
-    CodebergReleaser getCodeberg();
-
-    GenericGitReleaser getGeneric();
-
-    Releaser getReleaser();
+public interface BitbucketcloudReleaser extends Releaser {
+    String TYPE = "bitbucketcloud";
 }

--- a/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/upload/BitbucketcloudUploader.java
+++ b/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/upload/BitbucketcloudUploader.java
@@ -15,25 +15,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jreleaser.model.api.release;
-
-import org.jreleaser.model.api.common.Domain;
+package org.jreleaser.model.api.upload;
 
 /**
- * @author Andres Almiray
- * @since 0.1.0
+ * @author Hasnae Rehioui
+ * @since 1.7.0
  */
-public interface Release extends Domain {
-    BitbucketcloudReleaser getBitbucketcloud();
-    GithubReleaser getGithub();
+public interface BitbucketcloudUploader extends Uploader {
+    String TYPE = "bitbucketcloud";
 
-    GitlabReleaser getGitlab();
+    String getHost();
 
-    GiteaReleaser getGitea();
+    String getToken();
 
-    CodebergReleaser getCodeberg();
+    String getPackageName();
 
-    GenericGitReleaser getGeneric();
+    String getPackageVersion();
 
-    Releaser getReleaser();
+    String getProjectIdentifier();
 }

--- a/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/upload/Upload.java
+++ b/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/upload/Upload.java
@@ -29,6 +29,8 @@ import java.util.Map;
 public interface Upload extends Domain, Activatable {
     Map<String, ? extends ArtifactoryUploader> getArtifactory();
 
+    Map<String, ? extends BitbucketcloudUploader> getBitbucketcloud();
+
     Map<String, ? extends FtpUploader> getFtp();
 
     Map<String, ? extends GiteaUploader> getGitea();

--- a/core/jreleaser-engine/jreleaser-engine.gradle
+++ b/core/jreleaser-engine/jreleaser-engine.gradle
@@ -52,6 +52,7 @@ dependencies {
     api project(':jreleaser-webhooks-java-sdk')
     api project(':jreleaser-zulip-java-sdk')
     // release
+    api project(':jreleaser-bitbucketcloud-java-sdk')
     api project(':jreleaser-github-java-sdk')
     api project(':jreleaser-gitlab-java-sdk')
     api project(':jreleaser-gitea-java-sdk')

--- a/core/jreleaser-engine/src/main/java/org/jreleaser/engine/context/ModelAutoConfigurer.java
+++ b/core/jreleaser-engine/src/main/java/org/jreleaser/engine/context/ModelAutoConfigurer.java
@@ -28,6 +28,7 @@ import org.jreleaser.model.internal.JReleaserContext;
 import org.jreleaser.model.internal.JReleaserModel;
 import org.jreleaser.model.internal.common.Artifact;
 import org.jreleaser.model.internal.release.BaseReleaser;
+import org.jreleaser.model.internal.release.BitbucketcloudReleaser;
 import org.jreleaser.model.internal.release.CodebergReleaser;
 import org.jreleaser.model.internal.release.GithubReleaser;
 import org.jreleaser.model.internal.release.GitlabReleaser;
@@ -480,8 +481,12 @@ public final class ModelAutoConfigurer {
         try {
             boolean grs = resolveBoolean(org.jreleaser.model.api.JReleaserContext.GIT_ROOT_SEARCH, gitRootSearch);
             Repository repository = GitSdk.of(basedir, grs).getRemote();
-            BaseReleaser<?, ?> service = null;
+            BaseReleaser<?, ?> service;
             switch (repository.getKind()) {
+                case BITBUCKETCLOUD:
+                    service = new BitbucketcloudReleaser();
+                    model.getRelease().setBitbucketcloud((BitbucketcloudReleaser) service);
+                    break;
                 case GITHUB:
                     service = new GithubReleaser();
                     model.getRelease().setGithub((GithubReleaser) service);

--- a/core/jreleaser-engine/src/main/java/org/jreleaser/engine/release/Releasers.java
+++ b/core/jreleaser-engine/src/main/java/org/jreleaser/engine/release/Releasers.java
@@ -22,6 +22,7 @@ import org.jreleaser.extensions.api.workflow.WorkflowListenerException;
 import org.jreleaser.model.JReleaserException;
 import org.jreleaser.model.api.JReleaserCommand;
 import org.jreleaser.model.api.hooks.ExecutionEvent;
+import org.jreleaser.model.api.release.BitbucketcloudReleaser;
 import org.jreleaser.model.api.release.CodebergReleaser;
 import org.jreleaser.model.api.release.GenericGitReleaser;
 import org.jreleaser.model.api.release.GiteaReleaser;
@@ -75,6 +76,9 @@ public final class Releasers {
                 Releasers.class.getClassLoader()).spliterator(), false)
             .collect(Collectors.toMap(ReleaserBuilderFactory::getName, ReleaserBuilderFactory::getBuilder));
 
+        if (null != context.getModel().getRelease().getBitbucketcloud()) {
+            return (T) builders.get(BitbucketcloudReleaser.TYPE);
+        }
         if (null != context.getModel().getRelease().getGithub()) {
             return (T) builders.get(GithubReleaser.TYPE);
         }

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/release/BitbucketcloudReleaser.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/release/BitbucketcloudReleaser.java
@@ -1,0 +1,284 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2023 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.model.internal.release;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.jreleaser.model.Active;
+import org.jreleaser.model.api.common.CommitAuthor;
+import org.jreleaser.model.api.release.Changelog;
+
+import java.util.Map;
+
+import static java.util.Collections.unmodifiableMap;
+
+/**
+ * @author Hasnae Rehioui
+ * @since 1.7.0
+ */
+public class BitbucketcloudReleaser extends BaseReleaser<org.jreleaser.model.api.release.BitbucketcloudReleaser, BitbucketcloudReleaser> {
+    private static final long serialVersionUID = 3160208925103963195L;
+
+    @JsonIgnore
+    private final org.jreleaser.model.api.release.BitbucketcloudReleaser immutable = new org.jreleaser.model.api.release.BitbucketcloudReleaser() {
+        private static final long serialVersionUID = -7158952152230034613L;
+
+        @Override
+        public String getServiceName() {
+            return BitbucketcloudReleaser.this.getServiceName();
+        }
+
+        @Override
+        public boolean isReleaseSupported() {
+            return BitbucketcloudReleaser.this.isReleaseSupported();
+        }
+
+        @Override
+        public String getCanonicalRepoName() {
+            return BitbucketcloudReleaser.this.getCanonicalRepoName();
+        }
+
+        @Override
+        public String getReverseRepoHost() {
+            return BitbucketcloudReleaser.this.getReverseRepoHost();
+        }
+
+        @Override
+        public boolean isMatch() {
+            return BitbucketcloudReleaser.this.isMatch();
+        }
+
+        @Override
+        public String getHost() {
+            return BitbucketcloudReleaser.this.getHost();
+        }
+
+        @Override
+        public String getName() {
+            return BitbucketcloudReleaser.this.getName();
+        }
+
+        @Override
+        public String getRepoUrl() {
+            return BitbucketcloudReleaser.this.getRepoUrl();
+        }
+
+        @Override
+        public String getRepoCloneUrl() {
+            return BitbucketcloudReleaser.this.getRepoCloneUrl();
+        }
+
+        @Override
+        public String getCommitUrl() {
+            return BitbucketcloudReleaser.this.getCommitUrl();
+        }
+
+        @Override
+        public String getSrcUrl() {
+            return BitbucketcloudReleaser.this.getSrcUrl();
+        }
+
+        @Override
+        public String getDownloadUrl() {
+            return BitbucketcloudReleaser.this.getDownloadUrl();
+        }
+
+        @Override
+        public String getReleaseNotesUrl() {
+            return BitbucketcloudReleaser.this.getReleaseNotesUrl();
+        }
+
+        @Override
+        public String getLatestReleaseUrl() {
+            return BitbucketcloudReleaser.this.getLatestReleaseUrl();
+        }
+
+        @Override
+        public String getIssueTrackerUrl() {
+            return BitbucketcloudReleaser.this.getIssueTrackerUrl();
+        }
+
+        @Override
+        public String getUsername() {
+            return BitbucketcloudReleaser.this.getUsername();
+        }
+
+        @Override
+        public String getToken() {
+            return BitbucketcloudReleaser.this.getToken();
+        }
+
+        @Override
+        public String getTagName() {
+            return BitbucketcloudReleaser.this.getTagName();
+        }
+
+        @Override
+        public String getPreviousTagName() {
+            return BitbucketcloudReleaser.this.getPreviousTagName();
+        }
+
+        @Override
+        public String getReleaseName() {
+            return BitbucketcloudReleaser.this.getReleaseName();
+        }
+
+        @Override
+        public String getBranch() {
+            return BitbucketcloudReleaser.this.getBranch();
+        }
+
+        @Override
+        public String getBranchPush() {
+            return BitbucketcloudReleaser.this.getBranchPush();
+        }
+
+        @Override
+        public Prerelease getPrerelease() {
+            return BitbucketcloudReleaser.this.getPrerelease().asImmutable();
+        }
+
+        @Override
+        public boolean isSign() {
+            return BitbucketcloudReleaser.this.isSign();
+        }
+
+        @Override
+        public Changelog getChangelog() {
+            return BitbucketcloudReleaser.this.getChangelog().asImmutable();
+        }
+
+        @Override
+        public Milestone getMilestone() {
+            return BitbucketcloudReleaser.this.getMilestone().asImmutable();
+        }
+
+        @Override
+        public Issues getIssues() {
+            return BitbucketcloudReleaser.this.getIssues().asImmutable();
+        }
+
+        @Override
+        public boolean isSkipTag() {
+            return BitbucketcloudReleaser.this.isSkipTag();
+        }
+
+        @Override
+        public boolean isSkipRelease() {
+            return BitbucketcloudReleaser.this.isSkipRelease();
+        }
+
+        @Override
+        public boolean isOverwrite() {
+            return BitbucketcloudReleaser.this.isOverwrite();
+        }
+
+        @Override
+        public Update getUpdate() {
+            return BitbucketcloudReleaser.this.getUpdate().asImmutable();
+        }
+
+        @Override
+        public String getApiEndpoint() {
+            return BitbucketcloudReleaser.this.getApiEndpoint();
+        }
+
+        @Override
+        public boolean isArtifacts() {
+            return BitbucketcloudReleaser.this.isArtifacts();
+        }
+
+        @Override
+        public boolean isFiles() {
+            return BitbucketcloudReleaser.this.isFiles();
+        }
+
+        @Override
+        public boolean isChecksums() {
+            return BitbucketcloudReleaser.this.isChecksums();
+        }
+
+        @Override
+        public boolean isCatalogs() {
+            return BitbucketcloudReleaser.this.isCatalogs();
+        }
+
+        @Override
+        public boolean isSignatures() {
+            return BitbucketcloudReleaser.this.isSignatures();
+        }
+
+        @Override
+        public Active getUploadAssets() {
+            return BitbucketcloudReleaser.this.getUploadAssets();
+        }
+
+        @Override
+        public boolean isPrerelease() {
+            return BitbucketcloudReleaser.this.isPrerelease();
+        }
+
+        @Override
+        public CommitAuthor getCommitAuthor() {
+            return BitbucketcloudReleaser.this.getCommitAuthor().asImmutable();
+        }
+
+        @Override
+        public Map<String, Object> asMap(boolean full) {
+            return unmodifiableMap(BitbucketcloudReleaser.this.asMap(full));
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return BitbucketcloudReleaser.this.isEnabled();
+        }
+
+        @Override
+        public String getOwner() {
+            return BitbucketcloudReleaser.this.getOwner();
+        }
+
+        @Override
+        public Integer getConnectTimeout() {
+            return BitbucketcloudReleaser.this.getConnectTimeout();
+        }
+
+        @Override
+        public Integer getReadTimeout() {
+            return BitbucketcloudReleaser.this.getReadTimeout();
+        }
+    };
+
+    public BitbucketcloudReleaser() {
+        super(org.jreleaser.model.api.release.BitbucketcloudReleaser.TYPE, true);
+        setHost("bitbucket.org");
+        setRepoUrl("https://{{repoHost}}/{{repoOwner}}/{{repoName}}");
+        setRepoCloneUrl("https://{{repoHost}}/{{repoOwner}}/{{repoName}}.git");
+        setCommitUrl("https:://{{repoHost}}/{{repoOwner}}/{{repoName}}/commits");
+        setSrcUrl("https://{{repoHost}}/{{repoOwner}}/{{repoName}}/src/{{repoBranch}}");
+    }
+
+    @Override
+    public String getReverseRepoHost() {
+        return "org.bitbucket";
+    }
+
+    @Override
+    public org.jreleaser.model.api.release.BitbucketcloudReleaser asImmutable() {
+        return immutable;
+    }
+}

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/release/Release.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/release/Release.java
@@ -32,8 +32,9 @@ import static org.jreleaser.model.JReleaserOutput.nag;
  * @since 0.1.0
  */
 public final class Release extends AbstractModelObject<Release> implements Domain {
-    private static final long serialVersionUID = -7382956682399917298L;
+    private static final long serialVersionUID = -5298669498248848715L;
 
+    private BitbucketcloudReleaser bitbucketcloud;
     private GithubReleaser github;
     private GitlabReleaser gitlab;
     private GiteaReleaser gitea;
@@ -42,7 +43,12 @@ public final class Release extends AbstractModelObject<Release> implements Domai
 
     @JsonIgnore
     private final org.jreleaser.model.api.release.Release immutable = new org.jreleaser.model.api.release.Release() {
-        private static final long serialVersionUID = 8607297611597648860L;
+        private static final long serialVersionUID = 3509724730197389700L;
+
+        @Override
+        public org.jreleaser.model.api.release.BitbucketcloudReleaser getBitbucketcloud() {
+            return null != bitbucketcloud ? bitbucketcloud.asImmutable() : null;
+        }
 
         @Override
         public org.jreleaser.model.api.release.GithubReleaser getGithub() {
@@ -86,11 +92,20 @@ public final class Release extends AbstractModelObject<Release> implements Domai
 
     @Override
     public void merge(Release source) {
+        this.bitbucketcloud = merge(this.bitbucketcloud, source.bitbucketcloud);
         this.github = merge(this.github, source.github);
         this.gitlab = merge(this.gitlab, source.gitlab);
         this.gitea = merge(this.gitea, source.gitea);
         this.codeberg = merge(this.codeberg, source.codeberg);
         this.generic = merge(this.generic, source.generic);
+    }
+
+    public BitbucketcloudReleaser getBitbucketcloud() {
+        return bitbucketcloud;
+    }
+
+    public void setBitbucketcloud(BitbucketcloudReleaser bitbucketcloud) {
+        this.bitbucketcloud = bitbucketcloud;
     }
 
     public GithubReleaser getGithub() {
@@ -135,6 +150,7 @@ public final class Release extends AbstractModelObject<Release> implements Domai
     }
 
     public BaseReleaser<?, ?> getReleaser() {
+        if (null != bitbucketcloud) return bitbucketcloud;
         if (null != github) return github;
         if (null != gitlab) return gitlab;
         if (null != gitea) return gitea;
@@ -143,6 +159,7 @@ public final class Release extends AbstractModelObject<Release> implements Domai
     }
 
     public org.jreleaser.model.api.release.Releaser releaser() {
+        if (null != bitbucketcloud) return bitbucketcloud.asImmutable();
         if (null != github) return github.asImmutable();
         if (null != gitlab) return gitlab.asImmutable();
         if (null != gitea) return gitea.asImmutable();
@@ -154,6 +171,7 @@ public final class Release extends AbstractModelObject<Release> implements Domai
     @Override
     public Map<String, Object> asMap(boolean full) {
         Map<String, Object> map = new LinkedHashMap<>();
+        if (null != bitbucketcloud) map.put(org.jreleaser.model.api.release.BitbucketcloudReleaser.TYPE, bitbucketcloud.asMap(full));
         if (null != github) map.put(org.jreleaser.model.api.release.GithubReleaser.TYPE, github.asMap(full));
         if (null != gitlab) map.put(org.jreleaser.model.api.release.GitlabReleaser.TYPE, gitlab.asMap(full));
         if (null != gitea) map.put(org.jreleaser.model.api.release.GiteaReleaser.TYPE, gitea.asMap(full));

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/upload/BitbucketcloudUploader.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/upload/BitbucketcloudUploader.java
@@ -1,0 +1,170 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2023 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.model.internal.upload;
+
+import org.jreleaser.model.Active;
+import org.jreleaser.model.internal.common.Artifact;
+import org.jreleaser.mustache.TemplateContext;
+
+import java.util.Map;
+
+import static java.util.Collections.unmodifiableMap;
+import static org.jreleaser.mustache.Templates.resolveTemplate;
+
+/**
+ * @author Hasnae Rehioui
+ * @since 1.7.0
+ */
+public class BitbucketcloudUploader extends AbstractGitPackageUploader<org.jreleaser.model.api.upload.BitbucketcloudUploader, BitbucketcloudUploader> {
+    private static final long serialVersionUID = -2516884046138936300L;
+    private static final String DOWNLOAD_URL = "https://{{host}}/2.0/repositories/{{projectIdentifier}}/{{packageName}}/downloads/{{artifactFile}}";
+
+    private String projectIdentifier;
+
+    private final org.jreleaser.model.api.upload.BitbucketcloudUploader immutable = new org.jreleaser.model.api.upload.BitbucketcloudUploader() {
+        private static final long serialVersionUID = 3571755247298525266L;
+
+        @Override
+        public String getHost() {
+            return BitbucketcloudUploader.this.getHost();
+        }
+
+        @Override
+        public String getToken() {
+            return BitbucketcloudUploader.this.getToken();
+        }
+
+        @Override
+        public String getPackageName() {
+            return BitbucketcloudUploader.this.getPackageName();
+        }
+
+        @Override
+        public String getPackageVersion() {
+            return BitbucketcloudUploader.this.getPackageVersion();
+        }
+
+        @Override
+        public String getProjectIdentifier() {
+            return BitbucketcloudUploader.this.getProjectIdentifier();
+        }
+
+        @Override
+        public String getType() {
+            return BitbucketcloudUploader.this.getType();
+        }
+
+        @Override
+        public String getName() {
+            return BitbucketcloudUploader.this.getName();
+        }
+
+        @Override
+        public boolean isSnapshotSupported() {
+            return BitbucketcloudUploader.this.isSnapshotSupported();
+        }
+
+        @Override
+        public boolean isArtifacts() {
+            return BitbucketcloudUploader.this.isArtifacts();
+        }
+
+        @Override
+        public boolean isFiles() {
+            return BitbucketcloudUploader.this.isFiles();
+        }
+
+        @Override
+        public boolean isSignatures() {
+            return BitbucketcloudUploader.this.isSignatures();
+        }
+
+        @Override
+        public boolean isChecksums() {
+            return BitbucketcloudUploader.this.isChecksums();
+        }
+
+        @Override
+        public boolean isCatalogs() {
+            return BitbucketcloudUploader.this.isCatalogs();
+        }
+
+        @Override
+        public Active getActive() {
+            return BitbucketcloudUploader.this.getActive();
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return BitbucketcloudUploader.this.isEnabled();
+        }
+
+        @Override
+        public Map<String, Object> asMap(boolean full) {
+            return unmodifiableMap(BitbucketcloudUploader.this.asMap(full));
+        }
+
+        @Override
+        public String getPrefix() {
+            return BitbucketcloudUploader.this.prefix();
+        }
+
+        @Override
+        public Map<String, Object> getExtraProperties() {
+            return unmodifiableMap(BitbucketcloudUploader.this.getExtraProperties());
+        }
+
+        @Override
+        public Integer getConnectTimeout() {
+            return BitbucketcloudUploader.this.getConnectTimeout();
+        }
+
+        @Override
+        public Integer getReadTimeout() {
+            return BitbucketcloudUploader.this.getReadTimeout();
+        }
+    };
+
+    public BitbucketcloudUploader() {
+        super(org.jreleaser.model.api.upload.BitbucketcloudUploader.TYPE);
+        setHost("api.bitbucket.org");
+    }
+
+    public String getProjectIdentifier() {
+        return projectIdentifier;
+    }
+
+    public void setProjectIdentifier(String projectIdentifier) {
+        this.projectIdentifier = projectIdentifier;
+    }
+
+    @Override
+    public org.jreleaser.model.api.upload.BitbucketcloudUploader asImmutable() {
+        return immutable;
+    }
+
+    @Override
+    public String getResolvedDownloadUrl(TemplateContext props, Artifact artifact) {
+        TemplateContext p = new TemplateContext(artifactProps(props, artifact));
+        p.setAll(resolvedExtraProperties());
+        p.set("host", getHost());
+        p.set("projectIdentifier", getProjectIdentifier());
+        p.set("packageName", getPackageName());
+        return resolveTemplate(DOWNLOAD_URL, p);
+    }
+}

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/release/BitbucketcloudReleaserValidator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/release/BitbucketcloudReleaserValidator.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2023 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.model.internal.validation.release;
+
+
+import org.jreleaser.model.api.JReleaserContext.Mode;
+import org.jreleaser.model.internal.JReleaserContext;
+import org.jreleaser.model.internal.release.BitbucketcloudReleaser;
+import org.jreleaser.util.Errors;
+
+import static org.jreleaser.model.internal.validation.release.BaseReleaserValidator.validateGitService;
+
+/**
+ * @author Hasnae Rehioui
+ * @since 1.7.0
+ */
+public class BitbucketcloudReleaserValidator {
+    private BitbucketcloudReleaserValidator() {
+        // noop
+    }
+
+    public static boolean validateBitbucketcloud(JReleaserContext context, Mode mode, BitbucketcloudReleaser service, Errors errors) {
+        if (null == service) return false;
+        context.getLogger().debug("release.bitbucketcloud");
+
+        validateGitService(context, mode, service, errors);
+
+        return service.isEnabled();
+    }
+}

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/release/ReleaseValidator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/release/ReleaseValidator.java
@@ -23,6 +23,7 @@ import org.jreleaser.model.internal.JReleaserContext;
 import org.jreleaser.model.internal.release.Release;
 import org.jreleaser.util.Errors;
 
+import static org.jreleaser.model.internal.validation.release.BitbucketcloudReleaserValidator.validateBitbucketcloud;
 import static org.jreleaser.model.internal.validation.release.CodebergReleaserValidator.validateCodeberg;
 import static org.jreleaser.model.internal.validation.release.GenericGitReleaserValidator.validateGeneric;
 import static org.jreleaser.model.internal.validation.release.GiteaReleaserValidator.validateGitea;
@@ -43,6 +44,7 @@ public final class ReleaseValidator {
         Release release = context.getModel().getRelease();
 
         int count = 0;
+        if (validateBitbucketcloud(context, mode, release.getBitbucketcloud(), errors)) count++;
         if (validateGithub(context, mode, release.getGithub(), errors)) count++;
         if (validateGitlab(context, mode, release.getGitlab(), errors)) count++;
         if (validateGitea(context, mode, release.getGitea(), errors)) count++;

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/upload/BitbucketcloudUploaderValidator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/upload/BitbucketcloudUploaderValidator.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2023 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.model.internal.validation.upload;
+
+import org.jreleaser.bundle.RB;
+import org.jreleaser.model.internal.JReleaserContext;
+import org.jreleaser.model.api.JReleaserContext.Mode;
+import org.jreleaser.model.internal.upload.BitbucketcloudUploader;
+import org.jreleaser.util.Errors;
+
+import java.util.Map;
+
+import static org.jreleaser.model.internal.validation.common.Validator.checkProperty;
+import static org.jreleaser.model.internal.validation.common.Validator.resolveActivatable;
+import static org.jreleaser.model.internal.validation.common.Validator.validateTimeout;
+import static org.jreleaser.util.CollectionUtils.listOf;
+import static org.jreleaser.util.StringUtils.isBlank;
+
+/**
+ * @author Hasnae Rehioui
+ * @since 1.7.0
+ */
+public class BitbucketcloudUploaderValidator {
+    private BitbucketcloudUploaderValidator() {
+        // noop
+    }
+
+    public static void validateBitbucketcloud(JReleaserContext context, Mode mode, Errors errors) {
+        Map<String, BitbucketcloudUploader> bitbucketcloud = context.getModel().getUpload().getBitbucketcloud();
+        if (!bitbucketcloud.isEmpty()) context.getLogger().debug("upload.bitbucketcloud");
+
+        for (Map.Entry<String, BitbucketcloudUploader> e: bitbucketcloud.entrySet()) {
+            e.getValue().setName(e.getKey());
+            if (mode.validateConfig()) {
+                validateBitbucketcloud(context, e.getValue(), errors);
+            }
+        }
+    }
+
+    private static void validateBitbucketcloud(JReleaserContext context, BitbucketcloudUploader uploader, Errors errors) {
+        context.getLogger().debug("upload.bitbucketcloud.{}", uploader.getName());
+
+        resolveActivatable(context, uploader,
+            listOf("upload.bitbucketcloud." + uploader.getName(), "upload.bitbucketcloud"),
+            "NEVER");
+
+        if (!uploader.resolveEnabledWithSnapshot(context.getModel().getProject())) {
+            context.getLogger().debug(RB.$("validation.disabled"));
+            return;
+        }
+
+        if (!uploader.isArtifacts() && !uploader.isFiles() && !uploader.isSignatures()) {
+            errors.warning(RB.$("WARNING.validation.uploader.no.artifacts", uploader.getType(), uploader.getName()));
+            context.getLogger().debug(RB.$("validation.disabled.no.artifacts"));
+            uploader.disable();
+            return;
+        }
+
+        String baseKey1 = "upload.bitbucketcloud." + uploader.getName();
+        String baseKey2 = "upload.bitbucketcloud";
+        String baseKey3 = "bitbucketcloud." + uploader.getName();
+        String baseKey4 = "bitbucketcloud";
+
+        uploader.setToken(
+            checkProperty(context,
+                listOf(
+                    baseKey1 + ".token",
+                    baseKey2 + ".token",
+                    baseKey3 + ".token",
+                    baseKey4 + ".token"),
+                baseKey1 + ".token",
+                uploader.getToken(),
+                errors,
+                context.isDryrun()));
+
+        if (isBlank(uploader.getPackageName())) {
+            uploader.setPackageName(uploader.getName());
+        }
+        if (isBlank(uploader.getPackageVersion())) {
+            uploader.setPackageVersion("{{projectVersion}}");
+        }
+
+        if (isBlank(uploader.getProjectIdentifier())) {
+            errors.configuration(RB.$("validation_must_not_be_blank", baseKey1 + ".projectIdentifier"));
+        }
+
+        validateTimeout(uploader);
+    }
+}

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/upload/UploadersValidator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/upload/UploadersValidator.java
@@ -25,6 +25,7 @@ import org.jreleaser.util.Errors;
 
 import static org.jreleaser.model.internal.validation.common.Validator.resolveActivatable;
 import static org.jreleaser.model.internal.validation.upload.ArtifactoryUploaderValidator.validateArtifactory;
+import static org.jreleaser.model.internal.validation.upload.BitbucketcloudUploaderValidator.validateBitbucketcloud;
 import static org.jreleaser.model.internal.validation.upload.FtpUploaderValidator.validateFtpUploader;
 import static org.jreleaser.model.internal.validation.upload.GiteaUploaderValidator.validateGiteaUploader;
 import static org.jreleaser.model.internal.validation.upload.GitlabUploaderValidator.validateGitlabUploader;
@@ -47,6 +48,7 @@ public final class UploadersValidator {
         context.getLogger().debug("upload");
 
         validateArtifactory(context, mode, errors);
+        validateBitbucketcloud(context, mode, errors);
         validateFtpUploader(context, mode, errors);
         validateGiteaUploader(context, mode, errors);
         validateGitlabUploader(context, mode, errors);
@@ -62,6 +64,7 @@ public final class UploadersValidator {
 
             if (upload.isEnabled()) {
                 boolean enabled = !upload.getActiveArtifactories().isEmpty() ||
+                    !upload.getActiveBitbucketclouds().isEmpty() ||
                     !upload.getActiveFtps().isEmpty() ||
                     !upload.getActiveGiteas().isEmpty() ||
                     !upload.getActiveGitlabs().isEmpty() ||

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/spi/release/Repository.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/spi/release/Repository.java
@@ -86,6 +86,7 @@ public class Repository {
     }
 
     public enum Kind {
+        BITBUCKETCLOUD,
         GITHUB,
         GITLAB,
         CODEBERG,

--- a/sdks/jreleaser-bitbucketcloud-java-sdk/gradle.properties
+++ b/sdks/jreleaser-bitbucketcloud-java-sdk/gradle.properties
@@ -1,0 +1,20 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2020-2023 The JReleaser authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+project_description = Java SDK for Bitbucket Cloud
+automatic.module.name = org.jreleaser.sdk.bitbucketcloud

--- a/sdks/jreleaser-bitbucketcloud-java-sdk/jreleaser-bitbucketcloud-java-sdk.gradle
+++ b/sdks/jreleaser-bitbucketcloud-java-sdk/jreleaser-bitbucketcloud-java-sdk.gradle
@@ -15,25 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jreleaser.model.api.release;
+dependencies {
+    compileOnly "org.kordamp.jipsy:jipsy-annotations:${jipsyVersion}"
+    annotationProcessor "org.kordamp.jipsy:jipsy-processor:${jipsyVersion}"
 
-import org.jreleaser.model.api.common.Domain;
+    api project(':jreleaser-java-sdk-commons')
 
-/**
- * @author Andres Almiray
- * @since 0.1.0
- */
-public interface Release extends Domain {
-    BitbucketcloudReleaser getBitbucketcloud();
-    GithubReleaser getGithub();
-
-    GitlabReleaser getGitlab();
-
-    GiteaReleaser getGitea();
-
-    CodebergReleaser getCodeberg();
-
-    GenericGitReleaser getGeneric();
-
-    Releaser getReleaser();
+    testImplementation project(':jreleaser-test-support')
 }

--- a/sdks/jreleaser-bitbucketcloud-java-sdk/src/main/java/org/jreleaser/sdk/bitbucketcloud/Bitbucketcloud.java
+++ b/sdks/jreleaser-bitbucketcloud-java-sdk/src/main/java/org/jreleaser/sdk/bitbucketcloud/Bitbucketcloud.java
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2023 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.sdk.bitbucketcloud;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import feign.Feign;
+import feign.Request;
+import feign.Response;
+import feign.form.FormEncoder;
+import feign.jackson.JacksonDecoder;
+import org.jreleaser.bundle.RB;
+import org.jreleaser.logging.JReleaserLogger;
+import org.jreleaser.model.JReleaserVersion;
+import org.jreleaser.sdk.bitbucketcloud.api.BBCRepository;
+import org.jreleaser.sdk.bitbucketcloud.api.BitbucketcloudAPI;
+import org.jreleaser.sdk.commons.RestAPIException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Hasnae Rehioui
+ * @since 1.7.0
+ */
+public class Bitbucketcloud {
+    private static final String ENDPOINT = "https://api.bitbucket.org/2.0";
+
+    private final JReleaserLogger logger;
+    private final BitbucketcloudAPI api;
+
+    public Bitbucketcloud(JReleaserLogger logger, String token, int connectTimeout, int readTimeout) {
+        this.logger = logger;
+        ObjectMapper objectMapper = new ObjectMapper()
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .configure(SerializationFeature.INDENT_OUTPUT, true);
+
+        this.api = Feign.builder()
+            .encoder(new FormEncoder())
+            .decoder(new JacksonDecoder(objectMapper))
+            .requestInterceptor(template -> {
+                    template.header("User-Agent", "JReleaser/" + JReleaserVersion.getPlainVersion());
+                    template.header("Authorization", "Bearer " + token);
+                }
+            )
+            .options(new Request.Options(connectTimeout, TimeUnit.SECONDS, readTimeout, TimeUnit.SECONDS, true))
+            .target(BitbucketcloudAPI.class, ENDPOINT);
+    }
+
+    public JReleaserLogger getLogger() {
+        return logger;
+    }
+
+    public Response uploadArtifact(String workspace, String repoName, Path artifact) throws IOException {
+        logger.debug(RB.$("uploader.uploading.to", "bitbucketcloud"));
+        return api.uploadArtifact(workspace, repoName, new File[] {
+            artifact.toFile()
+        });
+    }
+
+    public BBCRepository findRepository(String owner, String repo) {
+        logger.debug(RB.$("git.repository.lookup"), owner, repo);
+        try {
+            return api.getRepository(owner, repo);
+        } catch (RestAPIException e) {
+            if (e.isNotFound()) {
+                return null;
+            }
+            throw e;
+        }
+    }
+
+    public BBCRepository createRepository(String owner, String repo) {
+        logger.debug(RB.$("git.repository.create"), owner, repo);
+
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("scm", "git");
+
+        return api.createRepository(owner, repo, data);
+    }
+}

--- a/sdks/jreleaser-bitbucketcloud-java-sdk/src/main/java/org/jreleaser/sdk/bitbucketcloud/BitbucketcloudArtifactUploader.java
+++ b/sdks/jreleaser-bitbucketcloud-java-sdk/src/main/java/org/jreleaser/sdk/bitbucketcloud/BitbucketcloudArtifactUploader.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2023 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.sdk.bitbucketcloud;
+
+import feign.Response;
+import org.jreleaser.bundle.RB;
+import org.jreleaser.model.internal.JReleaserContext;
+import org.jreleaser.model.internal.common.Artifact;
+import org.jreleaser.model.internal.upload.BitbucketcloudUploader;
+import org.jreleaser.model.spi.upload.UploadException;
+import org.jreleaser.sdk.commons.AbstractArtifactUploader;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Set;
+
+/**
+ * @author Hasnae Rehioui
+ * @since 1.7.0
+ */
+public class BitbucketcloudArtifactUploader extends AbstractArtifactUploader<org.jreleaser.model.api.upload.BitbucketcloudUploader, BitbucketcloudUploader> {
+
+    private BitbucketcloudUploader uploader;
+
+    public BitbucketcloudArtifactUploader(JReleaserContext context) {
+        super(context);
+    }
+
+    @Override
+    public BitbucketcloudUploader getUploader() {
+        return uploader;
+    }
+
+    @Override
+    public void setUploader(BitbucketcloudUploader uploader) {
+        this.uploader = uploader;
+    }
+
+    @Override
+    public String getType() {
+        return org.jreleaser.model.api.upload.BitbucketcloudUploader.TYPE;
+    }
+
+    @Override
+    public void upload(String name) throws UploadException {
+        Set<Artifact> artifacts = collectArtifacts();
+        if (artifacts.isEmpty()) {
+            context.getLogger().info(RB.$("artifacts.no.match"));
+        }
+
+        String token = uploader.getToken();
+        Bitbucketcloud api = new Bitbucketcloud(context.getLogger(), token, uploader.getConnectTimeout(), uploader.getReadTimeout());
+
+        for (Artifact artifact : artifacts) {
+            Path path = artifact.getEffectivePath(context);
+            context.getLogger().info(" - {}", path.getFileName());
+
+            if (context.isDryrun()) {
+                continue;
+            }
+
+            try {
+                Response response = api.uploadArtifact(uploader.getProjectIdentifier(), uploader.getPackageName(), path);
+                context.getLogger().info(RB.$("uploader.uploading.to", "bitbucketcloud: " + response.reason()));
+            } catch (IOException e) {
+                context.getLogger().trace(e);
+                throw new UploadException(RB.$("ERROR_unexpected_upload",
+                    context.getBasedir().relativize(path)), e);
+            }
+        }
+    }
+}

--- a/sdks/jreleaser-bitbucketcloud-java-sdk/src/main/java/org/jreleaser/sdk/bitbucketcloud/BitbucketcloudArtifactUploaderFactory.java
+++ b/sdks/jreleaser-bitbucketcloud-java-sdk/src/main/java/org/jreleaser/sdk/bitbucketcloud/BitbucketcloudArtifactUploaderFactory.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2023 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.sdk.bitbucketcloud;
+
+import org.jreleaser.model.internal.JReleaserContext;
+import org.jreleaser.model.internal.upload.BitbucketcloudUploader;
+import org.jreleaser.model.spi.upload.ArtifactUploaderFactory;
+import org.kordamp.jipsy.annotations.ServiceProviderFor;
+
+/**
+ * @author Hasnae Rehioui
+ * @since 1.7.0
+ */
+@ServiceProviderFor(ArtifactUploaderFactory.class)
+public class BitbucketcloudArtifactUploaderFactory implements ArtifactUploaderFactory<org.jreleaser.model.api.upload.BitbucketcloudUploader, BitbucketcloudUploader, BitbucketcloudArtifactUploader> {
+
+    @Override
+    public String getName() {
+        return org.jreleaser.model.api.upload.BitbucketcloudUploader.TYPE;
+    }
+
+    @Override
+    public BitbucketcloudArtifactUploader getArtifactUploader(JReleaserContext context) {
+        return new BitbucketcloudArtifactUploader(context);
+    }
+}

--- a/sdks/jreleaser-bitbucketcloud-java-sdk/src/main/java/org/jreleaser/sdk/bitbucketcloud/BitbucketcloudReleaser.java
+++ b/sdks/jreleaser-bitbucketcloud-java-sdk/src/main/java/org/jreleaser/sdk/bitbucketcloud/BitbucketcloudReleaser.java
@@ -1,0 +1,96 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2023 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.sdk.bitbucketcloud;
+
+import org.jreleaser.bundle.RB;
+import org.jreleaser.model.internal.JReleaserContext;
+import org.jreleaser.model.spi.release.Asset;
+import org.jreleaser.model.spi.release.Release;
+import org.jreleaser.model.spi.release.ReleaseException;
+import org.jreleaser.model.spi.release.Repository;
+import org.jreleaser.model.spi.release.User;
+import org.jreleaser.sdk.bitbucketcloud.api.BBCRepository;
+import org.jreleaser.sdk.git.release.AbstractReleaser;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Collections.emptyList;
+
+/**
+ * @author Hasnae Rehioui
+ * @since 1.7.0
+ */
+public class BitbucketcloudReleaser extends AbstractReleaser<org.jreleaser.model.api.release.BitbucketcloudReleaser> {
+    private static final long serialVersionUID = 5874983846985118132L;
+
+    private final org.jreleaser.model.internal.release.BitbucketcloudReleaser bitbucketcloud;
+
+    public BitbucketcloudReleaser(JReleaserContext context, Set<Asset> assets) {
+        super(context, assets);
+        bitbucketcloud = context.getModel().getRelease().getBitbucketcloud();
+    }
+
+    @Override
+    public org.jreleaser.model.api.release.BitbucketcloudReleaser getReleaser() {
+        return bitbucketcloud.asImmutable();
+    }
+
+    @Override
+    public Repository maybeCreateRepository(String owner, String repo, String password) throws IOException {
+        context.getLogger().debug(RB.$("git.repository.lookup"), owner, repo);
+        Bitbucketcloud api = new Bitbucketcloud(
+            context.getLogger(),
+            password,
+            bitbucketcloud.getConnectTimeout(),
+            bitbucketcloud.getReadTimeout()
+        );
+
+        BBCRepository repository = api.findRepository(owner, repo);
+        if (null == repository) {
+            repository = api.createRepository(owner, repo);
+        }
+
+        return new Repository(
+            Repository.Kind.BITBUCKETCLOUD,
+            owner,
+            repo,
+            repository.getLinks().getHtml().getHref(),
+            String.format("https://bitbucket.org/%s/%s.git", owner, repo)
+        );
+    }
+
+    @Override
+    public Optional<User> findUser(String email, String name) {
+       return Optional.empty();
+    }
+
+    @Override
+    public List<Release> listReleases(String owner, String repo) throws IOException {
+        return emptyList();
+    }
+
+    @Override
+    protected void createRelease() throws ReleaseException {
+        if (context.getModel().getRelease().getReleaser().isMatch()) {
+            super.createTag();
+        }
+    }
+}

--- a/sdks/jreleaser-bitbucketcloud-java-sdk/src/main/java/org/jreleaser/sdk/bitbucketcloud/BitbucketcloudReleaserBuilder.java
+++ b/sdks/jreleaser-bitbucketcloud-java-sdk/src/main/java/org/jreleaser/sdk/bitbucketcloud/BitbucketcloudReleaserBuilder.java
@@ -15,25 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jreleaser.model.api.release;
+package org.jreleaser.sdk.bitbucketcloud;
 
-import org.jreleaser.model.api.common.Domain;
+import org.jreleaser.sdk.git.release.AbstractReleaserBuilder;
 
 /**
- * @author Andres Almiray
- * @since 0.1.0
+ * @author Hasnae Rehioui
+ * @since 1.7.0
  */
-public interface Release extends Domain {
-    BitbucketcloudReleaser getBitbucketcloud();
-    GithubReleaser getGithub();
-
-    GitlabReleaser getGitlab();
-
-    GiteaReleaser getGitea();
-
-    CodebergReleaser getCodeberg();
-
-    GenericGitReleaser getGeneric();
-
-    Releaser getReleaser();
+public class BitbucketcloudReleaserBuilder extends AbstractReleaserBuilder<BitbucketcloudReleaser> {
+    @Override
+    public BitbucketcloudReleaser build() {
+        validate();
+        return new BitbucketcloudReleaser(context, assets);
+    }
 }

--- a/sdks/jreleaser-bitbucketcloud-java-sdk/src/main/java/org/jreleaser/sdk/bitbucketcloud/BitbucketcloudReleaserBuilderFactory.java
+++ b/sdks/jreleaser-bitbucketcloud-java-sdk/src/main/java/org/jreleaser/sdk/bitbucketcloud/BitbucketcloudReleaserBuilderFactory.java
@@ -15,25 +15,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jreleaser.model.api.release;
+package org.jreleaser.sdk.bitbucketcloud;
 
-import org.jreleaser.model.api.common.Domain;
+import org.jreleaser.model.spi.release.ReleaserBuilderFactory;
+import org.kordamp.jipsy.annotations.ServiceProviderFor;
 
 /**
- * @author Andres Almiray
- * @since 0.1.0
+ * @author Hasnae Rehioui
+ * @since 1.7.0
  */
-public interface Release extends Domain {
-    BitbucketcloudReleaser getBitbucketcloud();
-    GithubReleaser getGithub();
+@ServiceProviderFor(ReleaserBuilderFactory.class)
+public class BitbucketcloudReleaserBuilderFactory implements ReleaserBuilderFactory<BitbucketcloudReleaser, BitbucketcloudReleaserBuilder> {
+    @Override
+    public String getName() {
+        return org.jreleaser.model.api.release.BitbucketcloudReleaser.TYPE;
+    }
 
-    GitlabReleaser getGitlab();
-
-    GiteaReleaser getGitea();
-
-    CodebergReleaser getCodeberg();
-
-    GenericGitReleaser getGeneric();
-
-    Releaser getReleaser();
+    @Override
+    public BitbucketcloudReleaserBuilder getBuilder() {
+        return new BitbucketcloudReleaserBuilder();
+    }
 }

--- a/sdks/jreleaser-bitbucketcloud-java-sdk/src/main/java/org/jreleaser/sdk/bitbucketcloud/api/BBCLink.java
+++ b/sdks/jreleaser-bitbucketcloud-java-sdk/src/main/java/org/jreleaser/sdk/bitbucketcloud/api/BBCLink.java
@@ -15,25 +15,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jreleaser.model.api.release;
+package org.jreleaser.sdk.bitbucketcloud.api;
 
-import org.jreleaser.model.api.common.Domain;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
- * @author Andres Almiray
- * @since 0.1.0
+ * @author Hasnae Rehioui
+ * @since 1.7.0
  */
-public interface Release extends Domain {
-    BitbucketcloudReleaser getBitbucketcloud();
-    GithubReleaser getGithub();
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BBCLink {
+    private String href;
+    private String name;
 
-    GitlabReleaser getGitlab();
+    public String getHref() {
+        return href;
+    }
 
-    GiteaReleaser getGitea();
+    public void setHref(String href) {
+        this.href = href;
+    }
 
-    CodebergReleaser getCodeberg();
+    public String getName() {
+        return name;
+    }
 
-    GenericGitReleaser getGeneric();
-
-    Releaser getReleaser();
+    public void setName(String name) {
+        this.name = name;
+    }
 }

--- a/sdks/jreleaser-bitbucketcloud-java-sdk/src/main/java/org/jreleaser/sdk/bitbucketcloud/api/BBCRepository.java
+++ b/sdks/jreleaser-bitbucketcloud-java-sdk/src/main/java/org/jreleaser/sdk/bitbucketcloud/api/BBCRepository.java
@@ -15,25 +15,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jreleaser.model.api.release;
+package org.jreleaser.sdk.bitbucketcloud.api;
 
-import org.jreleaser.model.api.common.Domain;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
- * @author Andres Almiray
- * @since 0.1.0
+ * @author Hasnae Rehioui
+ * @since 1.7.0
  */
-public interface Release extends Domain {
-    BitbucketcloudReleaser getBitbucketcloud();
-    GithubReleaser getGithub();
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BBCRepository {
+    private String uuid;
+    private BBCRepositoryLinks links;
 
-    GitlabReleaser getGitlab();
+    public String getUuid() {
+        return uuid;
+    }
 
-    GiteaReleaser getGitea();
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
 
-    CodebergReleaser getCodeberg();
+    public BBCRepositoryLinks getLinks() {
+        return links;
+    }
 
-    GenericGitReleaser getGeneric();
-
-    Releaser getReleaser();
+    public void setLinks(BBCRepositoryLinks links) {
+        this.links = links;
+    }
 }

--- a/sdks/jreleaser-bitbucketcloud-java-sdk/src/main/java/org/jreleaser/sdk/bitbucketcloud/api/BBCRepositoryLinks.java
+++ b/sdks/jreleaser-bitbucketcloud-java-sdk/src/main/java/org/jreleaser/sdk/bitbucketcloud/api/BBCRepositoryLinks.java
@@ -15,25 +15,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jreleaser.model.api.release;
+package org.jreleaser.sdk.bitbucketcloud.api;
 
-import org.jreleaser.model.api.common.Domain;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
- * @author Andres Almiray
- * @since 0.1.0
+ * @author Hasnae Rehioui
+ * @since 1.7.0
  */
-public interface Release extends Domain {
-    BitbucketcloudReleaser getBitbucketcloud();
-    GithubReleaser getGithub();
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BBCRepositoryLinks {
+    private BBCLink html;
+    private BBCLink[] clone;
 
-    GitlabReleaser getGitlab();
+    public BBCLink getHtml() {
+        return html;
+    }
 
-    GiteaReleaser getGitea();
+    public void setHtml(BBCLink html) {
+        this.html = html;
+    }
 
-    CodebergReleaser getCodeberg();
+    public BBCLink[] getClone() {
+        return clone;
+    }
 
-    GenericGitReleaser getGeneric();
-
-    Releaser getReleaser();
+    public void setClone(BBCLink[] clone) {
+        this.clone = clone;
+    }
 }

--- a/sdks/jreleaser-bitbucketcloud-java-sdk/src/main/java/org/jreleaser/sdk/bitbucketcloud/api/BitbucketcloudAPI.java
+++ b/sdks/jreleaser-bitbucketcloud-java-sdk/src/main/java/org/jreleaser/sdk/bitbucketcloud/api/BitbucketcloudAPI.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2023 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.sdk.bitbucketcloud.api;
+
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+import feign.Response;
+import org.jreleaser.infra.nativeimage.annotations.ProxyConfig;
+
+import java.io.File;
+import java.util.Map;
+
+/**
+ * @author Hasnae Rehioui
+ * @since 1.7.0
+ */
+@ProxyConfig
+public interface BitbucketcloudAPI {
+
+    @RequestLine("POST /repositories/{workspace}/{repoName}/downloads")
+    @Headers("Content-Type: multipart/form-data")
+    Response uploadArtifact(
+        @Param("workspace") String workspace,
+        @Param("repoName") String repoName,
+        @Param("files") File[] file
+    );
+
+    @RequestLine("GET /repositories/{workspace}/{repoName}")
+    @Headers("Accept: application/json")
+    BBCRepository getRepository(
+        @Param("workspace") String workspace,
+        @Param("repoName") String repoName
+    );
+
+    @RequestLine("POST /repositories/{workspace}/{repoName}")
+    @Headers("Content-Type: application/json")
+    BBCRepository createRepository(
+        @Param("workspace") String workspace,
+        @Param("repoName") String repoName,
+        Map<String, Object> data
+    );
+}

--- a/sdks/jreleaser-git-java-sdk/src/main/java/org/jreleaser/sdk/git/ChangelogGenerator.java
+++ b/sdks/jreleaser-git-java-sdk/src/main/java/org/jreleaser/sdk/git/ChangelogGenerator.java
@@ -360,10 +360,11 @@ public class ChangelogGenerator {
         commits.stream()
             .sorted(revCommitComparator)
             .map(rc -> "conventional-commits".equals(changelog.getPreset()) ? ConventionalCommit.of(rc) : Commit.of(rc))
-            .map(c -> c.extractIssues(context))
             .peek(c -> {
                 applyLabels(c, changelog.getLabelers());
-
+                if (context.getModel().getRelease().getReleaser().getIssues().isEnabled()) {
+                    c.extractIssues(context);
+                }
                 if (!changelog.getContributors().isEnabled()) return;
 
                 if (!changelog.getHide().containsContributor(c.author.name)) {

--- a/sdks/jreleaser-git-java-sdk/src/main/java/org/jreleaser/sdk/git/GitSdk.java
+++ b/sdks/jreleaser-git-java-sdk/src/main/java/org/jreleaser/sdk/git/GitSdk.java
@@ -112,6 +112,9 @@ public class GitSdk {
 
             Repository.Kind kind = Repository.Kind.OTHER;
             switch (uri.getHost()) {
+                case "bitbucket.org":
+                    kind = Repository.Kind.BITBUCKETCLOUD;
+                    break;
                 case "github.com":
                     kind = Repository.Kind.GITHUB;
                     break;


### PR DESCRIPTION
Fixes #12 

### Context
- supports releasing to bitbucket cloud repository
- it does **not** include resolving an issue tracker (yet) , to be continued
   - we can support default issue tracker first with [bitbucket cloud group issue tracker api](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-issue-tracker/) 
   - and explore integration with jira for [version/release management}(https://support.atlassian.com/jira-software-cloud/docs/enable-releases-and-versions/)
- it includes artifact upload to bitbucket cloud
- **note**: 
    - I ran into some issues with git push using ssh locally, other than that everything works fine with repo access tokens and https remotes
    

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.

- [ ] register BitbucketcloudUploader with JsonSchemaGenerator
- [ ] use `Templates.resolveTemplate()` where applicable
- [ ] use `bitbucket` dsl with `mode` set to CLOUD vs DC/SERVER
