### PR TITLE
fix(deployer): add support for no fail on warning flag

### DIFF
--- a/sdks/jreleaser-java-sdk-commons/src/main/java/org/jreleaser/sdk/commons/AbstractMavenDeployer.java
+++ b/sdks/jreleaser-java-sdk-commons/src/main/java/org/jreleaser/sdk/commons/AbstractMavenDeployer.java
@@ -213,6 +213,9 @@ public abstract class AbstractMavenDeployer<A extends org.jreleaser.model.api.de
                 getDeployer().isSnapshotSupported()) {
                 args.add("--no-release");
             }
+            if (pomChecker.hasNoFailOnWarningSupport()) {
+                args.add("--no-fail-on-warning");
+            }
             args.add("--file");
             args.add(deployable.getLocalPath().toAbsolutePath().toString());
 

--- a/sdks/jreleaser-tool-java-sdk/src/main/java/org/jreleaser/sdk/tool/PomChecker.java
+++ b/sdks/jreleaser-tool-java-sdk/src/main/java/org/jreleaser/sdk/tool/PomChecker.java
@@ -47,4 +47,8 @@ public class PomChecker extends AbstractTool {
         return executeCommand(() -> new CommandExecutor(context.getLogger())
             .executeCommand(parent, command));
     }
+
+    public boolean hasNoFailOnWarningSupport(){
+        return SemanticVersion.of(version).compareTo(SemanticVersion.of("1.9.0")) >= 0;
+    }
 }


### PR DESCRIPTION
Fixes #1397

### Context
Add the ``--no-fail-on-warning`` flag when running pomchecker when the version is above or equal 1.9.0.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.

cc: @elektro-wolle @fgaignat @jankohout95
