### PR TITLE
fix(deployer): add ability to configure if pomchecker should fail on error or on warning

### DIFF
--- a/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/deploy/maven/Maven.java
+++ b/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/deploy/maven/Maven.java
@@ -43,5 +43,7 @@ public interface Maven extends Domain, Activatable {
 
     interface Pomchecker extends Domain {
         String getVersion();
+        boolean isFailOnWarning();
+        boolean isFailOnError();
     }
 }

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/deploy/maven/Maven.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/deploy/maven/Maven.java
@@ -24,12 +24,7 @@ import org.jreleaser.model.internal.common.AbstractModelObject;
 import org.jreleaser.model.internal.common.Activatable;
 import org.jreleaser.model.internal.common.Domain;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import static java.util.Collections.unmodifiableMap;
 import static java.util.function.Function.identity;
@@ -432,17 +427,29 @@ public final class Maven extends AbstractActivatable<Maven> implements Domain, A
     }
 
     public static final class Pomchecker extends AbstractModelObject<Pomchecker> implements Domain {
-        private static final long serialVersionUID = 8467928554400937980L;
-
+        private static final long serialVersionUID = -3338690712854794960L;
         private String version;
+        private Boolean failOnWarning;
+        private Boolean failOnError;
+
 
         @JsonIgnore
         private final org.jreleaser.model.api.deploy.maven.Maven.Pomchecker immutable = new org.jreleaser.model.api.deploy.maven.Maven.Pomchecker() {
-            private static final long serialVersionUID = -7691641757680849149L;
+            private static final long serialVersionUID = 3245901294277040203L;
 
             @Override
             public String getVersion() {
                 return version;
+            }
+
+            @Override
+            public boolean isFailOnWarning() {
+                return failOnWarning;
+            }
+
+            @Override
+            public boolean isFailOnError() {
+                return failOnError;
             }
 
             @Override
@@ -458,6 +465,8 @@ public final class Maven extends AbstractActivatable<Maven> implements Domain, A
         @Override
         public void merge(Pomchecker source) {
             this.version = merge(this.version, source.version);
+            this.failOnWarning = merge(this.failOnWarning, source.failOnWarning);
+            this.failOnError = merge(this.failOnError, source.failOnError);
         }
 
         public String getVersion() {
@@ -468,10 +477,36 @@ public final class Maven extends AbstractActivatable<Maven> implements Domain, A
             this.version = version;
         }
 
+        public boolean isFailOnWarning() {
+            return failOnWarning != null && failOnWarning;
+        }
+
+        public boolean isFailOnWarningSet() {
+            return failOnWarning != null;
+        }
+
+        public void setFailOnWarning(Boolean failOnWarning) {
+            this.failOnWarning = failOnWarning;
+        }
+
+        public boolean isFailOnError() {
+            return failOnError != null && failOnError;
+        }
+
+        public boolean isFailOnErrorSet() {
+            return failOnError != null;
+        }
+
+        public void setFailOnError(Boolean failOnError) {
+            this.failOnError = failOnError;
+        }
+
         @Override
         public Map<String, Object> asMap(boolean full) {
             Map<String, Object> map = new LinkedHashMap<>();
             map.put("version", version);
+            map.put("failOnWarning", isFailOnWarning());
+            map.put("failOnError", isFailOnError());
             return map;
         }
     }

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/deploy/maven/MavenDeployersValidator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/deploy/maven/MavenDeployersValidator.java
@@ -87,6 +87,12 @@ public final class MavenDeployersValidator {
         if (isBlank(maven.getPomchecker().getVersion())) {
             maven.getPomchecker().setVersion(DefaultVersions.getInstance().getPomcheckerVersion());
         }
+        if (!maven.getPomchecker().isFailOnWarningSet()) {
+            maven.getPomchecker().setFailOnWarning(true);
+        }
+        if (!maven.getPomchecker().isFailOnErrorSet()) {
+            maven.getPomchecker().setFailOnError(true);
+        }
     }
 
     static void validateMavenDeployer(JReleaserContext context, MavenDeployer<?> mavenDeployer, Errors errors) {

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/dsl/deploy/maven/Maven.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/dsl/deploy/maven/Maven.groovy
@@ -73,5 +73,7 @@ interface Maven extends Activatable {
     @CompileStatic
     interface Pomchecker {
         Property<String> getVersion()
+        Property<Boolean> getFailOnError()
+        Property<Boolean> getFailOnWarning()
     }
 }

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/deploy/maven/MavenImpl.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/deploy/maven/MavenImpl.groovy
@@ -219,15 +219,21 @@ class MavenImpl implements Maven {
     @CompileStatic
     static class PomcheckerImpl implements Pomchecker {
         final Property<String> version
+        final Property<Boolean> failOnError
+        final Property<Boolean> failOnWarning
 
         @Inject
         PomcheckerImpl(ObjectFactory objects) {
             version = objects.property(String).convention(Providers.<String> notDefined())
+            failOnError = objects.property(Boolean).convention(Providers.<Boolean> notDefined())
+            failOnWarning = objects.property(Boolean).convention(Providers.<Boolean> notDefined())
         }
 
         org.jreleaser.model.internal.deploy.maven.Maven.Pomchecker toModel() {
             org.jreleaser.model.internal.deploy.maven.Maven.Pomchecker pomchecker = new org.jreleaser.model.internal.deploy.maven.Maven.Pomchecker()
             if (version.present) pomchecker.version = version.get()
+            if (failOnError.present) pomchecker.failOnError = failOnError.get()
+            if (failOnWarning.present) pomchecker.failOnWarning = failOnWarning.get()
             pomchecker
         }
     }

--- a/sdks/jreleaser-tool-java-sdk/src/main/java/org/jreleaser/sdk/tool/PomChecker.java
+++ b/sdks/jreleaser-tool-java-sdk/src/main/java/org/jreleaser/sdk/tool/PomChecker.java
@@ -48,7 +48,7 @@ public class PomChecker extends AbstractTool {
             .executeCommand(parent, command));
     }
 
-    public boolean hasNoFailOnWarningSupport(){
-        return SemanticVersion.of(version).compareTo(SemanticVersion.of("1.9.0")) >= 0;
+    public boolean isVersionCompatibleWith(String otherVersion){
+        return SemanticVersion.of(version).compareTo(SemanticVersion.of(otherVersion)) >= 0;
     }
 }


### PR DESCRIPTION
This Pr makes the pomchecker error/warning behaviour configurable
Fixes #1397


### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [X] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
