### PR TITLE
fix: honor gradle task property packagers.docker.repository.name

### DIFF
--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/packagers/DockerPackagerValidator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/packagers/DockerPackagerValidator.java
@@ -108,10 +108,12 @@ public final class DockerPackagerValidator {
         if (!repository.isVersionedSubfoldersSet()) {
             repository.setVersionedSubfolders(parentPackager.getPackagerRepository().isVersionedSubfolders());
         }
+        validateTap(context, distribution, repository, parentPackager.getRepositoryTap(), "docker.repository");
+
+        // perform after validateTap so that repository.name isn't squashed
         if (isBlank(repository.getName())) {
             repository.setName(project.getName() + "-docker");
         }
-        validateTap(context, distribution, repository, parentPackager.getRepositoryTap(), "docker.repository");
 
         mergeExtraProperties(packager, parentPackager);
         validateContinueOnError(packager, parentPackager);

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/packagers/DockerPackagerImpl.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/packagers/DockerPackagerImpl.groovy
@@ -182,7 +182,7 @@ class DockerPackagerImpl extends AbstractDockerConfiguration implements DockerPa
             if (tagName.present) tap.tagName = tagName.get()
             if (branch.present) tap.branch = branch.get()
             if (branchPush.present) tap.branchPush = branchPush.get()
-            if (username.present) tap.name = username.get()
+            if (username.present) tap.username = username.get()
             if (token.present) tap.token = token.get()
             if (commitMessage.present) tap.commitMessage = commitMessage.get()
             if (versionedSubfolders.present) tap.versionedSubfolders = versionedSubfolders.get()


### PR DESCRIPTION
resolves two issues. name value set to username. name value set prematurely before parent tap values are merged.

https://github.com/jreleaser/jreleaser/issues/1438

### Context
<!-- What problem does this change address? -->
<!-- Link to relevant issues or discussions here -->
See issue above

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
