### PR TITLE
fix: Use ROOT locale for TimeUtils formatting

### DIFF
--- a/api/jreleaser-utils/src/main/java/org/jreleaser/util/TimeUtils.java
+++ b/api/jreleaser-utils/src/main/java/org/jreleaser/util/TimeUtils.java
@@ -19,6 +19,7 @@ package org.jreleaser.util;
 
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.util.Locale;
 
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static org.jreleaser.util.StringUtils.padLeft;
@@ -42,7 +43,7 @@ public final class TimeUtils {
     public static String formatDuration(double time) {
         if (time <= 0d) time = 0d;
 
-        String formatted = String.format("%.3f", time) + " s";
+        String formatted = String.format(Locale.ROOT, "%.3f", time) + " s";
 
         if (time >= 60d) {
             int seconds = (int) time;


### PR DESCRIPTION
### Context
<!-- What problem does this change address? -->
<!-- Link to relevant issues or discussions here -->
Fixes test failures on systems with a locale using anything but `.` as decimal separator.
Alternatively, if this is desired, you can change the test expectations.

Example error:
```
java.lang.AssertionError: 
Expected: "0.500 s"
     but: was "0,500 s"
    at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
    at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
    at org.jreleaser.util.TimeUtilsTest.testTimeFactory(TimeUtilsTest.java:37)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```

### Checklist
- [ ] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
