### PR TITLE
fix(assemble): Add missing template option bindings to jlink

### DIFF
--- a/core/jreleaser-engine/src/main/java/org/jreleaser/assemblers/JlinkAssemblerProcessor.java
+++ b/core/jreleaser-engine/src/main/java/org/jreleaser/assemblers/JlinkAssemblerProcessor.java
@@ -48,6 +48,9 @@ import static org.jreleaser.assemblers.AssemblerUtils.readJavaVersion;
 import static org.jreleaser.model.Constants.KEY_ARCHIVE_FORMAT;
 import static org.jreleaser.model.Constants.KEY_DISTRIBUTION_ASSEMBLE_DIRECTORY;
 import static org.jreleaser.model.Constants.KEY_DISTRIBUTION_EXECUTABLE;
+import static org.jreleaser.model.Constants.KEY_DISTRIBUTION_JAVA_MAIN_CLASS;
+import static org.jreleaser.model.Constants.KEY_DISTRIBUTION_JAVA_MAIN_JAR;
+import static org.jreleaser.model.Constants.KEY_DISTRIBUTION_JAVA_MAIN_MODULE;
 import static org.jreleaser.mustache.Templates.resolveTemplate;
 import static org.jreleaser.util.FileType.BAT;
 import static org.jreleaser.util.FileType.JAR;
@@ -68,6 +71,14 @@ public class JlinkAssemblerProcessor extends AbstractAssemblerProcessor<org.jrel
     @Override
     protected void fillAssemblerProperties(TemplateContext props) {
         super.fillAssemblerProperties(props);
+        if (isNotBlank(assembler.getMainJar().getPath())) {
+            props.set(KEY_DISTRIBUTION_JAVA_MAIN_JAR, assembler.getMainJar().getEffectivePath(context, assembler)
+                .getFileName());
+        } else {
+            props.set(KEY_DISTRIBUTION_JAVA_MAIN_JAR, "");
+        }
+        props.set(KEY_DISTRIBUTION_JAVA_MAIN_CLASS, assembler.getJava().getMainClass());
+        props.set(KEY_DISTRIBUTION_JAVA_MAIN_MODULE, assembler.getJava().getMainModule());
         props.set(KEY_DISTRIBUTION_EXECUTABLE, assembler.getExecutable());
     }
 


### PR DESCRIPTION
Fix missing template variable binding in jlink assembler.

Add distributionJavaMainModule, distributionJavaMainClass and distributionJavaMainJar to template context in JlinkAssemblerProcessor similarly it's done in JavaArchiveAssemblerProcessor.

This fix don't try to add distributionJavaOptions as that's not used in a jlink template and assembler structure seems to be slightly different compared to java-archive.

Fixes #1496

I didn't find any tests to tweak.