### PR TITLE
fix(packagers): Fix quoting and path issues in windows launchers

### DIFF
--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/java-archive/java-archive/bin/launcher.bat.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/java-archive/java-archive/bin/launcher.bat.tpl
@@ -32,7 +32,7 @@ goto fail
 
 :findJavaFromJavaHome
 set JAVA_HOME=%JAVA_HOME:"=%
-set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+set JAVA_EXE=%JAVA_HOME%\bin\java.exe
 
 if exist "%JAVA_EXE%" goto execute
 
@@ -47,14 +47,16 @@ goto fail
 :execute
 @rem Setup the command line
 
-set JARSDIRS="%APP_HOME%\lib"
+set JARSDIRS=%APP_HOME%\lib
 {{#distributionJavaMainModule}}
-set CLASSPATH="%JARSDIRS%"
+set CLASSPATH=%JARSDIRS%
 {{/distributionJavaMainModule}}
 {{^distributionJavaMainModule}}
-set CLASSPATH="%JARSDIRS%\*"
+set CLASSPATH=%JARSDIRS%\*
 {{/distributionJavaMainModule}}
-set JAVA_OPTS="%JAVA_OPTS% {{distributionJavaOptions}}"
+{{#distributionJavaOptions}}
+set JAVA_OPTS=%JAVA_OPTS% {{.}}
+{{/distributionJavaOptions}}
 
 @rem Execute
 {{#distributionJavaMainModule}}

--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/jlink/jlink/bin/launcher.bat.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/jlink/jlink/bin/launcher.bat.tpl
@@ -48,16 +48,18 @@ for %%i in ("%~dp0..") do set "BASEDIR=%%~fi"
 
 :javaSetup
 
-set JAVA_HOME="%BASEDIR%"
+set JAVA_HOME=%BASEDIR%
 set JAVACMD="%JAVA_HOME%\bin\java"
-set JARSDIRS="%BASEDIR%\jars"
+set JARSDIRS=%BASEDIR%\jars
 {{#distributionJavaMainModule}}
-set CLASSPATH="%JARSDIRS%"
+set CLASSPATH=%JARSDIRS%
 {{/distributionJavaMainModule}}
 {{^distributionJavaMainModule}}
-set CLASSPATH="%JARSDIRS%\*"
+set CLASSPATH=%JARSDIRS%\*
 {{/distributionJavaMainModule}}
-set JAVA_OPTS="%JAVA_OPTS% {{distributionJavaOptions}}"
+{{#distributionJavaOptions}}
+set JAVA_OPTS=%JAVA_OPTS% {{.}}
+{{/distributionJavaOptions}}
 
 @REM Reaching here means variables are defined and arguments have been captured
 :endInit


### PR DESCRIPTION
- This commit fixes various errors in windows launcher templates for java-archive and jlink.
- JAVA_OPTS as whole cannot be surrounded with quotes as windows shell would then treat that as single argument and jvm blows up. Quotes could be used with individual JAVA_OPTS arguments but that is then solely left to user.
- If java options are coming from distribution settings(ie jreleaser.yml) then we simply append to JAVA_OPTS as is without quoting.
- In java-archive template java.exe is changed to backslash like it already was in jlink template.
- Running java command also contained mixed double quoting and is fixed by removing quotes from JAVACMD.
- Classpath contained mixed triple quoting and is fixed by removing quotes from JARSDIRS and CLASSPATH

Fixes #1634

Here's few examples what a new launchers would look like with different settings. I know that jreleaser doesn't use options in yml but simulated what it would look like. Lemmy know what you think!

With java-archive

Defaults

```
C:\Users\User\Downloads\jreleaser-early-access\jreleaser-1.12.0-SNAPSHOT\bin>"C:\Program Files\BellSoft\LibericaJDK-17-Full\/bin/java.exe"   -cp "C:\Users\User\Downloads\jreleaser-early-access\jreleaser-1.12.0-SNAPSHOT\lib\*" org.jreleaser.cli.Main
```

set JAVA_OPTS=-Xnoclassgc

```
C:\Users\User\Downloads\jreleaser-early-access\jreleaser-1.12.0-SNAPSHOT\bin>"C:\Program Files\BellSoft\LibericaJDK-17-Full\/bin/java.exe"  -Xnoclassgc -cp "C:\Users\User\Downloads\jreleaser-early-access\jreleaser-1.12.0-SNAPSHOT\lib\*" org.jreleaser.cli.Main
```

distributionJavaOptions

```
C:\Users\User\Downloads\jreleaser-early-access\jreleaser-1.12.0-SNAPSHOT\bin>"C:\Program Files\BellSoft\LibericaJDK-17-Full\/bin/java.exe"   -Xms1G -Xmx1G -cp "C:\Users\User\Downloads\jreleaser-early-access\jreleaser-1.12.0-SNAPSHOT\lib\*" org.jreleaser.cli.Main
```

set JAVA_OPTS=-Xnoclassgc
distributionJavaOptions

```
C:\Users\User\Downloads\jreleaser-early-access\jreleaser-1.12.0-SNAPSHOT\bin>"C:\Program Files\BellSoft\LibericaJDK-17-Full\/bin/java.exe"  -Xnoclassgc -Xms1G -Xmx1G -cp "C:\Users\User\Downloads\jreleaser-early-access\jreleaser-1.12.0-SNAPSHOT\lib\*" org.jreleaser.cli.Main
```

With jlink

defaults

```
C:\Users\User\Downloads\jreleaser-standalone-early-access-windows-x86_64\jreleaser-standalone-early-access-windows-x86_64\bin>"C:\Users\User\Downloads\jreleaser-standalone-early-access-windows-x86_64\jreleaser-standalone-early-access-windows-x86_64\bin\java"   -cp "C:\Users\User\Downloads\jreleaser-standalone-early-access-windows-x86_64\jreleaser-standalone-early-access-windows-x86_64\jars\*" org.jreleaser.cli.Main
```

set JAVA_OPTS=-Xnoclassgc

```
C:\Users\User\Downloads\jreleaser-standalone-early-access-windows-x86_64\jreleaser-standalone-early-access-windows-x86_64\bin>"C:\Users\User\Downloads\jreleaser-standalone-early-access-windows-x86_64\jreleaser-standalone-early-access-windows-x86_64\bin\java"  -Xnoclassgc -cp "C:\Users\User\Downloads\jreleaser-standalone-early-access-windows-x86_64\jreleaser-standalone-early-access-windows-x86_64\jars\*" org.jreleaser.cli.Main
```

distributionJavaOptions

```
C:\Users\User\Downloads\jreleaser-standalone-early-access-windows-x86_64\jreleaser-standalone-early-access-windows-x86_64\bin>"C:\Users\User\Downloads\jreleaser-standalone-early-access-windows-x86_64\jreleaser-standalone-early-access-windows-x86_64\bin\java"   -Xms1G -Xmx1G -cp "C:\Users\User\Downloads\jreleaser-standalone-early-access-windows-x86_64\jreleaser-standalone-early-access-windows-x86_64\jars\*" org.jreleaser.cli.Main
```

set JAVA_OPTS=-Xnoclassgc
distributionJavaOptions

```
C:\Users\User\Downloads\jreleaser-standalone-early-access-windows-x86_64\jreleaser-standalone-early-access-windows-x86_64\bin>"C:\Users\User\Downloads\jreleaser-standalone-early-access-windows-x86_64\jreleaser-standalone-early-access-windows-x86_64\bin\java"  -Xnoclassgc -Xms1G -Xmx1G -cp "C:\Users\User\Downloads\jreleaser-standalone-early-access-windows-x86_64\jreleaser-standalone-early-access-windows-x86_64\jars\*" org.jreleaser.cli.Main
```
