### PR TITLE
fix(deploy): Added a 'may deploy snapshots' property for deployments. This will be used to override e.g. GitHub Maven deployers that are totally allowed to publish snapshots.

### DIFF
--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/deploy/maven/AbstractMavenDeployer.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/deploy/maven/AbstractMavenDeployer.java
@@ -59,6 +59,7 @@ public abstract class AbstractMavenDeployer<S extends AbstractMavenDeployer<S, A
     protected Boolean javadocJar;
     protected Boolean verifyPom;
     protected Boolean applyMavenCentralRules;
+    protected Boolean mayDeploySnapshots;
     private String url;
     private String username;
     private String password;
@@ -84,6 +85,7 @@ public abstract class AbstractMavenDeployer<S extends AbstractMavenDeployer<S, A
         this.username = merge(this.username, source.getUsername());
         this.password = merge(this.password, source.getPassword());
         this.authorization = merge(this.authorization, source.getAuthorization());
+        this.mayDeploySnapshots = merge(this.mayDeploySnapshots, source.getMayDeploySnapshots());
         setExtraProperties(merge(this.extraProperties, source.getExtraProperties()));
         setStagingRepositories(merge(this.stagingRepositories, source.getStagingRepositories()));
         setArtifactOverrides(merge(this.artifactOverrides, source.getArtifactOverrides()));
@@ -312,6 +314,16 @@ public abstract class AbstractMavenDeployer<S extends AbstractMavenDeployer<S, A
     @Override
     public void setAuthorization(String authorization) {
         this.authorization = Http.Authorization.of(authorization);
+    }
+
+    @Override
+    public boolean getMayDeploySnapshots() {
+        return mayDeploySnapshots;
+    }
+
+    @Override
+    public void setMayDeploySnapshots(Boolean mayDeploySnapshots) {
+        this.mayDeploySnapshots = mayDeploySnapshots;
     }
 
     @Override

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/deploy/maven/AbstractMavenDeployer.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/deploy/maven/AbstractMavenDeployer.java
@@ -59,14 +59,19 @@ public abstract class AbstractMavenDeployer<S extends AbstractMavenDeployer<S, A
     protected Boolean javadocJar;
     protected Boolean verifyPom;
     protected Boolean applyMavenCentralRules;
-    protected Boolean mayDeploySnapshots;
+    protected Boolean snapshotSupported;
     private String url;
     private String username;
     private String password;
     private Http.Authorization authorization;
 
     protected AbstractMavenDeployer(String type) {
+        this(type, false);
+    }
+
+    protected AbstractMavenDeployer(String type, Boolean snapshotSupported) {
         this.type = type;
+        this.snapshotSupported = snapshotSupported;
     }
 
     @Override
@@ -85,7 +90,7 @@ public abstract class AbstractMavenDeployer<S extends AbstractMavenDeployer<S, A
         this.username = merge(this.username, source.getUsername());
         this.password = merge(this.password, source.getPassword());
         this.authorization = merge(this.authorization, source.getAuthorization());
-        this.mayDeploySnapshots = merge(this.mayDeploySnapshots, source.getMayDeploySnapshots());
+        this.snapshotSupported = merge(this.snapshotSupported, source.isSnapshotSupported());
         setExtraProperties(merge(this.extraProperties, source.getExtraProperties()));
         setStagingRepositories(merge(this.stagingRepositories, source.getStagingRepositories()));
         setArtifactOverrides(merge(this.artifactOverrides, source.getArtifactOverrides()));
@@ -94,11 +99,6 @@ public abstract class AbstractMavenDeployer<S extends AbstractMavenDeployer<S, A
     @Override
     public String prefix() {
         return getType();
-    }
-
-    @Override
-    public boolean isSnapshotSupported() {
-        return false;
     }
 
     @Override
@@ -317,13 +317,13 @@ public abstract class AbstractMavenDeployer<S extends AbstractMavenDeployer<S, A
     }
 
     @Override
-    public boolean getMayDeploySnapshots() {
-        return mayDeploySnapshots;
+    public boolean isSnapshotSupported() {
+        return snapshotSupported;
     }
 
     @Override
-    public void setMayDeploySnapshots(Boolean mayDeploySnapshots) {
-        this.mayDeploySnapshots = mayDeploySnapshots;
+    public void setSnapshotSupported(Boolean snapshotSupported) {
+        this.snapshotSupported = snapshotSupported;
     }
 
     @Override
@@ -345,6 +345,7 @@ public abstract class AbstractMavenDeployer<S extends AbstractMavenDeployer<S, A
         props.put("javadocJar", isJavadocJar());
         props.put("verifyPom", isVerifyPom());
         props.put("applyMavenCentralRules", isApplyMavenCentralRules());
+        props.put("snapshotSupported", isSnapshotSupported());
         props.put("stagingRepositories", stagingRepositories);
         Map<String, Map<String, Object>> mappedArtifacts = new LinkedHashMap<>();
         int i = 0;

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/deploy/maven/MavenCentralMavenDeployer.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/deploy/maven/MavenCentralMavenDeployer.java
@@ -256,11 +256,6 @@ public final class MavenCentralMavenDeployer extends AbstractMavenDeployer<Maven
     }
 
     @Override
-    public boolean isSnapshotSupported() {
-        return false;
-    }
-
-    @Override
     protected void asMap(boolean full, Map<String, Object> props) {
         props.put("stage", stage);
         props.put("namespace", namespace);

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/deploy/maven/MavenDeployer.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/deploy/maven/MavenDeployer.java
@@ -107,6 +107,10 @@ public interface MavenDeployer<A extends org.jreleaser.model.api.deploy.maven.Ma
 
     List<String> keysFor(String property);
 
+    boolean getMayDeploySnapshots();
+
+    void setMayDeploySnapshots(Boolean mayDeploySnapshots);
+
     final class ArtifactOverride extends AbstractModelObject<ArtifactOverride> implements Domain {
         private static final long serialVersionUID = 2308197517238220999L;
 

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/deploy/maven/MavenDeployer.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/deploy/maven/MavenDeployer.java
@@ -107,9 +107,7 @@ public interface MavenDeployer<A extends org.jreleaser.model.api.deploy.maven.Ma
 
     List<String> keysFor(String property);
 
-    boolean getMayDeploySnapshots();
-
-    void setMayDeploySnapshots(Boolean mayDeploySnapshots);
+    void setSnapshotSupported(Boolean snapshotSupported);
 
     final class ArtifactOverride extends AbstractModelObject<ArtifactOverride> implements Domain {
         private static final long serialVersionUID = 2308197517238220999L;

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/deploy/maven/Nexus2MavenDeployer.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/deploy/maven/Nexus2MavenDeployer.java
@@ -217,7 +217,7 @@ public final class Nexus2MavenDeployer extends AbstractMavenDeployer<Nexus2Maven
     };
 
     public Nexus2MavenDeployer() {
-        super(org.jreleaser.model.api.deploy.maven.Nexus2MavenDeployer.TYPE);
+        super(org.jreleaser.model.api.deploy.maven.Nexus2MavenDeployer.TYPE, true);
     }
 
     @Override
@@ -313,11 +313,6 @@ public final class Nexus2MavenDeployer extends AbstractMavenDeployer<Nexus2Maven
 
     public void setEndStage(org.jreleaser.model.api.deploy.maven.Nexus2MavenDeployer.Stage endStage) {
         this.endStage = endStage;
-    }
-
-    @Override
-    public boolean isSnapshotSupported() {
-        return true;
     }
 
     public String getResolvedSnapshotUrl(TemplateContext props) {

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/dsl/deploy/maven/MavenDeployer.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/dsl/deploy/maven/MavenDeployer.groovy
@@ -61,6 +61,8 @@ interface MavenDeployer extends Deployer {
 
     ListProperty<String> getStagingRepositories()
 
+    Property<Boolean> getMayDeploySnapshots()
+
     void artifactOverride(Action<? super ArtifactOverride> action)
 
     void artifactOverride(@DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = ArtifactOverride) Closure<Void> action)

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/dsl/deploy/maven/MavenDeployer.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/dsl/deploy/maven/MavenDeployer.groovy
@@ -61,7 +61,7 @@ interface MavenDeployer extends Deployer {
 
     ListProperty<String> getStagingRepositories()
 
-    Property<Boolean> getMayDeploySnapshots()
+    Property<Boolean> getSnapshotSupported()
 
     void artifactOverride(Action<? super ArtifactOverride> action)
 

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/deploy/maven/AbstractMavenDeployer.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/deploy/maven/AbstractMavenDeployer.groovy
@@ -57,7 +57,7 @@ abstract class AbstractMavenDeployer implements MavenDeployer {
     final Property<String> url
     final Property<String> username
     final Property<String> password
-    final Property<Boolean> mayDeploySnapshots
+    final Property<Boolean> snapshotSupported
     final Property<Http.Authorization> authorization
     final ListProperty<String> stagingRepositories
     final MapProperty<String, Object> extraProperties
@@ -81,7 +81,7 @@ abstract class AbstractMavenDeployer implements MavenDeployer {
         authorization = objects.property(Http.Authorization).convention(Providers.<Http.Authorization> notDefined())
         stagingRepositories = objects.listProperty(String).convention(Providers.<List<String>> notDefined())
         extraProperties = objects.mapProperty(String, Object).convention(Providers.notDefined())
-        mayDeploySnapshots = objects.property(Boolean).convention(false)
+        snapshotSupported = objects.property(Boolean).convention(false)
         artifactOverrides = objects.domainObjectContainer(ArtifactOverrideImpl, new NamedDomainObjectFactory<ArtifactOverrideImpl>() {
             @Override
             ArtifactOverrideImpl create(String name) {
@@ -156,6 +156,7 @@ abstract class AbstractMavenDeployer implements MavenDeployer {
         if (sourceJar.present) deployer.sourceJar = sourceJar.get()
         if (javadocJar.present) deployer.javadocJar = javadocJar.get()
         if (verifyPom.present) deployer.verifyPom = verifyPom.get()
+        if (snapshotSupported.present) deployer.snapshotSupported = snapshotSupported.get()
         if (applyMavenCentralRules.present) deployer.applyMavenCentralRules = applyMavenCentralRules.get()
         if (url.present) deployer.url = url.get()
         if (username.present) deployer.username = username.get()

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/deploy/maven/AbstractMavenDeployer.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/deploy/maven/AbstractMavenDeployer.groovy
@@ -57,6 +57,7 @@ abstract class AbstractMavenDeployer implements MavenDeployer {
     final Property<String> url
     final Property<String> username
     final Property<String> password
+    final Property<Boolean> mayDeploySnapshots
     final Property<Http.Authorization> authorization
     final ListProperty<String> stagingRepositories
     final MapProperty<String, Object> extraProperties
@@ -80,7 +81,7 @@ abstract class AbstractMavenDeployer implements MavenDeployer {
         authorization = objects.property(Http.Authorization).convention(Providers.<Http.Authorization> notDefined())
         stagingRepositories = objects.listProperty(String).convention(Providers.<List<String>> notDefined())
         extraProperties = objects.mapProperty(String, Object).convention(Providers.notDefined())
-
+        mayDeploySnapshots = objects.property(Boolean).convention(false)
         artifactOverrides = objects.domainObjectContainer(ArtifactOverrideImpl, new NamedDomainObjectFactory<ArtifactOverrideImpl>() {
             @Override
             ArtifactOverrideImpl create(String name) {


### PR DESCRIPTION
Added a 'may deploy snapshots' property for deployments. This will be used to override e.g. GitHub Maven deployers that are totally allowed to publish snapshots.
