### PR TITLE
fix(assemble): Use the correct comment syntax in Windows launchers

### DIFF
--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/java-archive/java-archive/bin/launcher.bat.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/java-archive/java-archive/bin/launcher.bat.tpl
@@ -55,20 +55,20 @@ set CLASSPATH=%JARSDIRS%
 set CLASSPATH=%JARSDIRS%\*
 {{/distributionJavaMainModule}}
 
-# universal JVM options
+@rem universal JVM options
 {{#distributionJavaJvmOptionsUniversal}}
 set JAVA_OPTS=%JAVA_OPTS% {{.}}
 {{/distributionJavaJvmOptionsUniversal}}
-# windows JVM options
+@rem windows JVM options
 {{#distributionJavaJvmOptionsWindows}}
 set JAVA_OPTS=%JAVA_OPTS% {{.}}
 {{/distributionJavaJvmOptionsWindows}}
 
-# universal environment variables
+@rem universal environment variables
 {{#distributionJavaEnvironmentVariablesUniversal}}
 set {{key}}="{{value}}"
 {{/distributionJavaEnvironmentVariablesUniversal}}
-# windows environment variables
+@rem windows environment variables
 {{#distributionJavaEnvironmentVariablesWindows}}
 set {{key}}="{{value}}"
 {{/distributionJavaEnvironmentVariablesWindows}}

--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/jlink/jlink/bin/launcher.bat.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/jlink/jlink/bin/launcher.bat.tpl
@@ -58,20 +58,20 @@ set CLASSPATH=%JARSDIRS%
 set CLASSPATH=%JARSDIRS%\*
 {{/distributionJavaMainModule}}
 
-# universal JVM options
+@rem universal JVM options
 {{#distributionJavaJvmOptionsUniversal}}
 set JAVA_OPTS=%JAVA_OPTS% {{.}}
 {{/distributionJavaJvmOptionsUniversal}}
-# windows JVM options
+@rem windows JVM options
 {{#distributionJavaJvmOptionsWindows}}
 set JAVA_OPTS=%JAVA_OPTS% {{.}}
 {{/distributionJavaJvmOptionsWindows}}
 
-# universal environment variables
+@rem universal environment variables
 {{#distributionJavaEnvironmentVariablesUniversal}}
 set {{key}}="{{value}}"
 {{/distributionJavaEnvironmentVariablesUniversal}}
-# windows environment variables
+@rem windows environment variables
 {{#distributionJavaEnvironmentVariablesWindows}}
 set {{key}}="{{value}}"
 {{/distributionJavaEnvironmentVariablesWindows}}


### PR DESCRIPTION
Fixes #1688.

### Context

In commit 8a9c36d, come comments starting with `#` were added in all launchers, but this syntax is not valid for .bat files.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
