### PR TITLE
fix(core): Fix "Cannot parse CALVER version" with 0Y.0M.MICRO/YY.0M.MICRO

### DIFF
--- a/api/jreleaser-model-api/src/main/java/org/jreleaser/version/CalVer.java
+++ b/api/jreleaser-model-api/src/main/java/org/jreleaser/version/CalVer.java
@@ -70,8 +70,8 @@ public class CalVer implements Version<CalVer> {
 
     static {
         PATTERNS.put(T_YEAR_LONG, "([2-9][0-9]{3})");
-        PATTERNS.put(T_YEAR_SHORT, "([1-9]|[1-9][0-9]|[1-9][0-9]{2})");
-        PATTERNS.put(T_YEAR_ZERO, "(0[1-9]|[1-9][0-9]|[1-9][0-9]{2})");
+        PATTERNS.put(T_YEAR_SHORT, "([0-9]|[1-9][0-9]|[1-9][0-9]{2})");
+        PATTERNS.put(T_YEAR_ZERO, "(0[0-9]|[1-9][0-9]|[1-9][0-9]{2})");
         PATTERNS.put(T_MONTH_SHORT, "([1-9]|1[0-2])");
         PATTERNS.put(T_MONTH_ZERO, "(0[1-9]|1[0-2])");
         PATTERNS.put(T_WEEK_SHORT, "([1-9]|[1-4][0-9]|5[0-2])");
@@ -465,7 +465,7 @@ public class CalVer implements Version<CalVer> {
 
         return of(format, format.replace(T_YEAR_LONG, "2000")
             .replace(T_YEAR_SHORT, "0")
-            .replace(T_YEAR_ZERO, "0")
+            .replace(T_YEAR_ZERO, "00")
             .replace(T_MONTH_SHORT, "1")
             .replace(T_MONTH_ZERO, "01")
             .replace(T_WEEK_SHORT, "1")

--- a/api/jreleaser-model-api/src/test/java/org/jreleaser/version/CalVerTest.java
+++ b/api/jreleaser-model-api/src/test/java/org/jreleaser/version/CalVerTest.java
@@ -53,6 +53,23 @@ class CalVerTest {
     }
 
     @ParameterizedTest
+    @MethodSource("default_version_parsing")
+    void testDefaultVersionParsing(String format, String year, String month, String day,
+                                   String week, String minor, String micro, String modifier) {
+        // given:
+        CalVer v = CalVer.defaultOf(format);
+
+        // then:
+        assertThat(v.getYear(), equalTo(year));
+        assertThat(v.getMonth(), equalTo(month));
+        assertThat(v.getDay(), equalTo(day));
+        assertThat(v.getWeek(), equalTo(week));
+        assertThat(v.getMinor(), equalTo(minor));
+        assertThat(v.getMicro(), equalTo(micro));
+        assertThat(v.getModifier(), equalTo(modifier));
+    }
+
+    @ParameterizedTest
     @MethodSource("version_invalid")
     void testVersionInvalid(String format, String input) {
         // expect:
@@ -97,7 +114,42 @@ class CalVerTest {
             Arguments.of("YYYY.MINOR.MICRO[-MODIFIER]", "2022.1.1", "2022", null, null, null, "1", "1", null),
             Arguments.of("YYYY.MINOR.MICRO[_MODIFIER]", "2022.1.1_beta2", "2022", null, null, null, "1", "1", "beta2"),
             Arguments.of("YYYY.MINOR.MICRO[_MODIFIER]", "2022.1.1", "2022", null, null, null, "1", "1", null),
-            Arguments.of("YYYY.MODIFIER", "2021.FOO-BAR", "2021", null, null, null, null, null, "FOO-BAR")
+            Arguments.of("YYYY.MODIFIER", "2021.FOO-BAR", "2021", null, null, null, null, null, "FOO-BAR"),
+            Arguments.of("0Y.0M.MICRO", "24.09.1", "24", "09", null, null, null, "1", null),
+            Arguments.of("0Y.0M.MICRO", "01.01.0", "01", "01", null, null, null, "0", null),
+            Arguments.of("0Y.MM.MICRO", "24.9.1", "24", "9", null, null, null, "1", null),
+            Arguments.of("0Y.MM.MICRO", "01.1.0", "01", "1", null, null, null, "0", null),
+            Arguments.of("YY.0M.MICRO", "24.09.1", "24", "09", null, null, null, "1", null),
+            Arguments.of("YY.0M.MICRO", "1.01.0", "1", "01", null, null, null, "0", null),
+            Arguments.of("YY.MM.MICRO", "24.9.1", "24", "9", null, null, null, "1", null),
+            Arguments.of("YY.MM.MICRO", "1.1.0", "1", "1", null, null, null, "0", null)
+        );
+    }
+
+    private static Stream<Arguments> default_version_parsing() {
+        return Stream.of(
+            Arguments.of("YYYY", "2000", null, null, null, null, null, null),
+            Arguments.of("YY", "0", null, null, null, null, null, null),
+            Arguments.of("0Y", "00", null, null, null, null, null, null),
+            Arguments.of("YYYY.MM", "2000", "1", null, null, null, null, null),
+            Arguments.of("YYYY.0M", "2000", "01", null, null, null, null, null),
+            Arguments.of("YYYY.MM.DD", "2000", "1", "1", null, null, null, null),
+            Arguments.of("YYYY.MM.0D", "2000", "1", "01", null, null, null, null),
+            Arguments.of("YYYY.WW", "2000", null, null, "1", null, null, null),
+            Arguments.of("YYYY.0W", "2000", null, null, "01", null, null, null),
+            Arguments.of("YYYY.MINOR.MICRO", "2000", null, null, null, "0", "0", null),
+            Arguments.of("YYYY.MM.DD_MICRO", "2000", "1", "1", null, null, "0", null),
+            Arguments.of("YYYY.MODIFIER", "2000", null, null, null, null, null, "A"),
+            Arguments.of("YYYY.MINOR.MICRO.MODIFIER", "2000", null, null, null, "0", "0", "A"),
+            Arguments.of("YYYY.MINOR.MICRO-MODIFIER", "2000", null, null, null, "0", "0", "A"),
+            Arguments.of("YYYY.MINOR.MICRO_MODIFIER", "2000", null, null, null, "0", "0", "A"),
+            Arguments.of("YYYY.MINOR.MICRO[.MODIFIER]", "2000", null, null, null, "0", "0", "A"),
+            Arguments.of("YYYY.MINOR.MICRO[-MODIFIER]", "2000", null, null, null, "0", "0", "A"),
+            Arguments.of("YYYY.MINOR.MICRO[_MODIFIER]", "2000", null, null, null, "0", "0", "A"),
+            Arguments.of("0Y.0M.MICRO", "00", "01", null, null, null, "0", null),
+            Arguments.of("0Y.MM.MICRO", "00", "1", null, null, null, "0", null),
+            Arguments.of("YY.0M.MICRO", "0", "01", null, null, null, "0", null),
+            Arguments.of("YY.MM.MICRO", "0", "1", null, null, null, "0", null)
         );
     }
 
@@ -120,7 +172,9 @@ class CalVerTest {
             Arguments.of("YY.MODIFIER", "21/A"),
             Arguments.of("YYYY.0M.DD", "2001.02.29"),
             Arguments.of("YYYY.0M.DD", "2001.09.31"),
-            Arguments.of("YYYY.0M.DD", "2001.01.32")
+            Arguments.of("YYYY.0M.DD", "2001.01.32"),
+            Arguments.of("YY.0M.MICRO", "00.01.0"),
+            Arguments.of("YY.MM.MICRO", "00.1.0")
         );
     }
 
@@ -133,7 +187,11 @@ class CalVerTest {
             Arguments.of("YYYY.MINOR.MICRO", "2021.1.2", "2021.1.3"),
             Arguments.of("YYYY.MODIFIER", "2021.ALPHA", "2021.BETA"),
             Arguments.of("YYYY.MINOR.MICRO[.MODIFIER]", "2000.0.0.ALPHA", "2000.0.0.BETA"),
-            Arguments.of("YYYY.MINOR.MICRO[.MODIFIER]", CalVer.defaultOf("YYYY.MINOR.MICRO[.MODIFIER]").toString(), "2000.0.0.B")
-        );
+            Arguments.of("YYYY.MINOR.MICRO[.MODIFIER]", CalVer.defaultOf("YYYY.MINOR.MICRO[.MODIFIER]").toString(), "2000.0.0.B"),
+            Arguments.of("0Y.0M.MICRO", "00.01.0", "01.01.0"),
+            Arguments.of("0Y.MM.MICRO", "00.1.0", "01.1.0"),
+            Arguments.of("YY.0M.MICRO", "0.01.0", "1.01.0"),
+            Arguments.of("YY.MM.MICRO", "0.1.0", "1.1.0")
+            );
     }
 }


### PR DESCRIPTION
Fixes #1728

### Context
- Updates pattern to `"(0[0-9]|[1-9][0-9]|[1-9][0-9]{2})"` for `0Y`, so `00.01.0` is correctly parsed as CALVER version
- Updates pattern to `"([0-9]|[1-9][0-9]|[1-9][0-9]{2})"` for `YY`, so `0.01.0` is correctly parsed as CALVER version
- Updates default CALVER value to `00` for `0Y`
- Fixes exceptions:
  - `IllegalArgumentException: Cannot parse version '0.01.0' with '0Y.0M.MICRO'`
  - `IllegalArgumentException: Cannot parse version '0.01.0' with 'YY.0M.MICRO'`
- Changes in Tests:
  - Creates Parameterized Test for `CalVer#defaultOf`
  - Updates existing tests to check `0Y.0M.MICRO`/`0Y.MM.MICRO`/`YY.0M.MICRO`/`YY.MM.MICRO` formats
- Changes in Docs: jreleaser/jreleaser.github.io#79

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.