### PR TITLE
chore: switch to new maintainers package and upgrade version

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -27,6 +27,6 @@ repositories {
 
 dependencies {
     compileOnly gradleApi()
-    implementation 'com.github.jengelman.gradle.plugins:shadow:6.1.0'
+    implementation 'com.gradleup.shadow:shadow-gradle-plugin:8.3.2'
     implementation 'org.kordamp.gradle:buildinfo-gradle-plugin:0.46.10'
 }


### PR DESCRIPTION
This change removes the dependency on log4j 2.13.2, which contains a critical vulnerability, by switching to the new maintainers package and upgrading the version.

https://github.com/GradleUp/shadow?tab=readme-ov-file#gradle-shadow

<!-- The issue this PR addresses -->
<!-- Please reference the issue this PR solves -->
Fixes #?

### Context
<!-- What problem does this change address? -->
<!-- Link to relevant issues or discussions here -->

### Checklist
- [ ] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [ ] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
