### PR TITLE
fix(release): Do not fail when GH tag not found

### DIFF
--- a/sdks/jreleaser-github-java-sdk/src/main/java/org/jreleaser/sdk/github/Github.java
+++ b/sdks/jreleaser-github-java-sdk/src/main/java/org/jreleaser/sdk/github/Github.java
@@ -325,7 +325,13 @@ class Github {
     void deleteTag(String owner, String repo, String tagName) throws RestAPIException {
         context.getLogger().debug(RB.$("git.delete.tag.from"), tagName, owner, repo);
 
-        api.deleteTag(owner, repo, tagName);
+        try {
+            api.deleteTag(owner, repo, tagName);
+        } catch (RestAPIException e) {
+            if (e.isNotFound()) {
+                context.getLogger().debug(RB.$("git.tag.not.exist"), tagName);
+            }
+        }
     }
 
     GhRelease createRelease(String owner, String repo, GhRelease release) throws RestAPIException {

--- a/sdks/jreleaser-github-java-sdk/src/test/java/org/jreleaser/sdk/github/ApiEndpoints.java
+++ b/sdks/jreleaser-github-java-sdk/src/test/java/org/jreleaser/sdk/github/ApiEndpoints.java
@@ -20,4 +20,5 @@ package org.jreleaser.sdk.github;
 public class ApiEndpoints {
     public static final String SEARCH_USERS = "/search/users";
     public static final String GET_USER_JRELEASER = "/users/jreleaserbot";
+    public static final String DELETE_TAG = "/repos/jreleaserbot/tests/git/refs/tags/test-tag";
 }


### PR DESCRIPTION
Fixes #1739 by handling HTTP 404 error response when deleting a GitHub tag.


### Context
<!-- What problem does this change address? -->
<!-- Link to relevant issues or discussions here -->

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
