### PR TITLE
fix: LinkedIn announcement Message contains distribution payload for PUBLIC MemberNetworkVisibility

### DIFF
--- a/sdks/jreleaser-linkedin-java-sdk/src/main/java/org/jreleaser/sdk/linkedin/api/Message.java
+++ b/sdks/jreleaser-linkedin-java-sdk/src/main/java/org/jreleaser/sdk/linkedin/api/Message.java
@@ -28,6 +28,10 @@ public class Message {
     private String owner;
     private String subject;
     private Text text;
+    private Distribution distribution = new Distribution();
+    {
+        distribution.setLinkedInDistributionTarget(new Distribution.Target());
+    }
 
     public String getOwner() {
         return owner;
@@ -53,6 +57,14 @@ public class Message {
         this.text = text;
     }
 
+    public Distribution getDistribution() {
+        return distribution;
+    }
+
+    public void setDistribution(Distribution distribution) {
+        this.distribution = distribution;
+    }
+
     public static Message of(String subject, String text) {
         Message message = new Message();
         message.subject = subject;
@@ -73,6 +85,23 @@ public class Message {
 
         public void setText(String text) {
             this.text = text;
+        }
+    }
+
+    public static final class Distribution {
+        private Target linkedInDistributionTarget = new Target();
+
+        public Target getLinkedInDistributionTarget() {
+            return linkedInDistributionTarget;
+        }
+
+        public void setLinkedInDistributionTarget(Target linkedInDistributionTarget) {
+            this.linkedInDistributionTarget = linkedInDistributionTarget;
+        }
+
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static final class Target {
+
         }
     }
 }

--- a/sdks/jreleaser-linkedin-java-sdk/src/main/java/org/jreleaser/sdk/linkedin/api/Message.java
+++ b/sdks/jreleaser-linkedin-java-sdk/src/main/java/org/jreleaser/sdk/linkedin/api/Message.java
@@ -29,9 +29,6 @@ public class Message {
     private String subject;
     private Text text;
     private Distribution distribution = new Distribution();
-    {
-        distribution.setLinkedInDistributionTarget(new Distribution.Target());
-    }
 
     public String getOwner() {
         return owner;

--- a/sdks/jreleaser-linkedin-java-sdk/src/test/java/org/jreleaser/sdk/linkedin/LinkedinSdkTest.java
+++ b/sdks/jreleaser-linkedin-java-sdk/src/test/java/org/jreleaser/sdk/linkedin/LinkedinSdkTest.java
@@ -75,6 +75,9 @@ class LinkedinSdkTest {
                 "  \"subject\" : \"App 1.0.0 released\",\n" +
                 "  \"text\" : {\n" +
                 "    \"text\" : \"App 1.0.0 has been released\"\n" +
+                "  },\n" +
+                "  \"distribution\": {\n" +
+                "    \"linkedInDistributionTarget\": { }\n" +
                 "  }\n" +
                 "}");
     }
@@ -105,6 +108,9 @@ class LinkedinSdkTest {
                 "  \"subject\" : \"App 1.0.0 released\",\n" +
                 "  \"text\" : {\n" +
                 "    \"text\" : \"App 1.0.0 has been released\"\n" +
+                "  },\n" +
+                "  \"distribution\": {\n" +
+                "    \"linkedInDistributionTarget\": { }\n" +
                 "  }\n" +
                 "}");
     }


### PR DESCRIPTION
Fixes #1794
Fixes #1789

### Context
JSON payload added to the LinkedIn message.  
