### PR TITLE
fix: correct JSON syntax in init template

### DIFF
--- a/core/jreleaser-engine/jreleaser-engine.gradle
+++ b/core/jreleaser-engine/jreleaser-engine.gradle
@@ -22,6 +22,7 @@ dependencies {
     api project(':jreleaser-tool-java-sdk')
     api project(':jreleaser-signing-java-sdk')
     api project(':jreleaser-command-java-sdk')
+    testRuntimeOnly project(':jreleaser-config-json')
 
     api "org.apache.commons:commons-text:$commonsTextVersion"
     api "com.github.victools:jsonschema-generator:$jsonSchemaVersion"

--- a/core/jreleaser-engine/src/test/java/org/jreleaser/engine/init/InitTest.java
+++ b/core/jreleaser-engine/src/test/java/org/jreleaser/engine/init/InitTest.java
@@ -1,3 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2025 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jreleaser.engine.init;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/core/jreleaser-engine/src/test/java/org/jreleaser/engine/init/InitTest.java
+++ b/core/jreleaser-engine/src/test/java/org/jreleaser/engine/init/InitTest.java
@@ -1,0 +1,28 @@
+package org.jreleaser.engine.init;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class InitTest {
+    @Test
+    void jsonSyntaxIsCorrect(@TempDir Path outputDirectory) {
+        // given:
+        String format = "json";
+
+        // when:
+        Init.execute(null, format, false, outputDirectory);
+        Path outputFile = outputDirectory.resolve("jreleaser." + format);
+
+        // then:
+        assertDoesNotThrow(() -> {
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.readTree(Files.readString(outputFile));
+        });
+    }
+}

--- a/core/jreleaser-engine/src/test/java/org/jreleaser/engine/init/InitTest.java
+++ b/core/jreleaser-engine/src/test/java/org/jreleaser/engine/init/InitTest.java
@@ -1,6 +1,8 @@
 package org.jreleaser.engine.init;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jreleaser.logging.JReleaserLogger;
+import org.jreleaser.logging.SimpleJReleaserLoggerAdapter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -14,9 +16,10 @@ public class InitTest {
     void jsonSyntaxIsCorrect(@TempDir Path outputDirectory) {
         // given:
         String format = "json";
+        JReleaserLogger logger = new SimpleJReleaserLoggerAdapter();
 
         // when:
-        Init.execute(null, format, false, outputDirectory);
+        Init.execute(logger, format, false, outputDirectory);
         Path outputFile = outputDirectory.resolve("jreleaser." + format);
 
         // then:

--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/init/jreleaser.json.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/init/jreleaser.json.tpl
@@ -11,12 +11,12 @@
     "links": {
       "homepage": "https://acme.com/app"
     },
-    "languages" {
+    "languages": {
         "java": {
           "groupId": "com.acme",
           "version": "8"
-        },
-    }
+        }
+    },
     "inceptionYear": "@year@"
   },
 


### PR DESCRIPTION
<!-- The issue this PR addresses -->
<!-- Please reference the issue this PR solves -->
Fixes #1814 

### Context

Fixes the JSON syntax in template.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
