### PR TITLE
fix!: correct parameter name for overwriting jreleaser.json

### DIFF
--- a/plugins/jreleaser-maven-plugin/src/main/java/org/jreleaser/maven/plugin/JReleaserInitMojo.java
+++ b/plugins/jreleaser-maven-plugin/src/main/java/org/jreleaser/maven/plugin/JReleaserInitMojo.java
@@ -64,7 +64,7 @@ public class JReleaserInitMojo extends AbstractMojo {
     /**
      * Overwrite existing files.
      */
-    @Parameter(property = "jreleaser.template.overwrite")
+    @Parameter(property = "jreleaser.init.overwrite")
     private boolean overwrite;
 
     @Override


### PR DESCRIPTION
<!-- The issue this PR addresses -->
<!-- Please reference the issue this PR solves -->

### Context
<!-- What problem does this change address? -->
<!-- Link to relevant issues or discussions here -->

There is mismatch in the parameter name for overwriting between documentation and source. Reference: https://github.com/jreleaser/jreleaser.github.io/pull/83.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
