### PR TITLE
feat(deploy): Add Maven metadata transformation for snapshot releases

### DIFF
--- a/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/deploy/maven/MavenDeployer.java
+++ b/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/deploy/maven/MavenDeployer.java
@@ -17,12 +17,15 @@
  */
 package org.jreleaser.model.api.deploy.maven;
 
+import static org.jreleaser.util.StringUtils.isBlank;
+
 import org.jreleaser.model.Http;
 import org.jreleaser.model.api.common.Domain;
 import org.jreleaser.model.api.common.TimeoutAware;
 import org.jreleaser.model.api.deploy.Deployer;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -68,5 +71,14 @@ public interface MavenDeployer extends Deployer, TimeoutAware {
         boolean isJavadocJar();
 
         boolean isVerifyPom();
+    }
+
+    enum MavenMetadataTransformationMode {
+        DISABLED, MERGE, RECREATE;
+
+        public static MavenMetadataTransformationMode of(String str) {
+            if (isBlank(str)) return null;
+            return MavenMetadataTransformationMode.valueOf(str.toUpperCase(Locale.ENGLISH).trim());
+        }
     }
 }

--- a/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/deploy/maven/Nexus2MavenDeployer.java
+++ b/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/deploy/maven/Nexus2MavenDeployer.java
@@ -32,6 +32,8 @@ public interface Nexus2MavenDeployer extends MavenDeployer {
 
     String getSnapshotUrl();
 
+    String getSnapshotServiceUrl();
+
     String getVerifyUrl();
 
     boolean isCloseRepository();
@@ -49,6 +51,8 @@ public interface Nexus2MavenDeployer extends MavenDeployer {
     Stage getStartStage();
 
     Stage getEndStage();
+
+    MavenMetadataTransformationMode getMavenMetadataTransformationMode();
 
     enum Stage {
         UPLOAD,

--- a/api/jreleaser-resource-bundle/src/main/resources/org/jreleaser/bundle/Messages.properties
+++ b/api/jreleaser-resource-bundle/src/main/resources/org/jreleaser/bundle/Messages.properties
@@ -127,6 +127,13 @@ ERROR_artifact_does_not_exist             = Artifact does not exist. {}
 ERROR_unexpected_error_hash_read          = Unexpected error when reading hash from {}
 ERROR_unexpected_error_calculate_checksum = Unexpected error calculating checksum for {}
 
+mavenMetadataTransformation.header               = Transforming Maven metadata XMLs
+mavenMetadataTransformation.processing           = Transforming Maven metadata XML in: {}
+mavenMetadataTransformation.retry.attempt        = Attempt downloading Maven metadata XML {} of {}
+mavenMetadataTransformation.retry.failed.attempt = attempt {}/{} failed with result: {}
+mavenMetadataTransformation.result               = Transformed Maven metadata XMLs: {}
+ERROR_unexpected_error_transforming_metadata     = Unexpected error transforming the Maven metadata XML {}
+
 packagers.packager.excluded                = packager {} was excluded. Skipping
 distributions.distribution.excluded        = distribution {} was excluded. Skipping
 distributions.not.enabled                  = No active distributions for {}. Skipping

--- a/api/jreleaser-utils/src/main/java/org/jreleaser/util/MavenMetadataTransformationUtils.java
+++ b/api/jreleaser-utils/src/main/java/org/jreleaser/util/MavenMetadataTransformationUtils.java
@@ -1,0 +1,174 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2025 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.util;
+
+import javax.xml.stream.XMLEventFactory;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLEventWriter;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.events.XMLEvent;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.Writer;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.regex.Pattern;
+
+/**
+ * @since 1.18.0
+ */
+public class MavenMetadataTransformationUtils {
+
+    private static final Pattern VERSION_PATTERN = Pattern.compile("\\d++\\.\\d++\\.\\d++.*+");
+    private static final DateTimeFormatter LAST_UPDATED_FORMAT = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+
+    private MavenMetadataTransformationUtils() {
+        // prevent instantiation
+    }
+
+    public static void recreateMetadataXml(byte[] in, String version, String groupId, String artifactId, Writer out, Comparator<String> versionComparator) throws javax.xml.stream.XMLStreamException {
+        recreateMetadataXml(new ByteArrayInputStream(in), version, groupId, artifactId, out, versionComparator);
+    }
+
+    public static void recreateMetadataXml(InputStream in, String version, String groupId, String artifactId, Writer out, Comparator<String> versionComparator) throws javax.xml.stream.XMLStreamException {
+        String latest = version;
+
+        XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+        XMLOutputFactory outFactory = XMLOutputFactory.newInstance();
+        XMLEventFactory eventFactory = XMLEventFactory.newInstance();
+
+        XMLEventReader reader = xmlInputFactory.createXMLEventReader(in);
+        XMLEventWriter writer = outFactory.createXMLEventWriter(out);
+
+        writer.add(eventFactory.createStartDocument());
+        writer.add(eventFactory.createCharacters("\n"));
+        writer.add(eventFactory.createStartElement("", "", "metadata"));
+        writer.add(eventFactory.createCharacters("\n  "));
+        writer.add(eventFactory.createStartElement("", "", "groupId"));
+        writer.add(eventFactory.createCharacters(groupId));
+        writer.add(eventFactory.createEndElement("", "", "groupId"));
+        writer.add(eventFactory.createCharacters("\n  "));
+        writer.add(eventFactory.createStartElement("", "", "artifactId"));
+        writer.add(eventFactory.createCharacters(artifactId));
+        writer.add(eventFactory.createEndElement("", "", "artifactId"));
+        writer.add(eventFactory.createCharacters("\n  "));
+        writer.add(eventFactory.createStartElement("", "", "versioning"));
+        writer.add(eventFactory.createCharacters("\n    "));
+        writer.add(eventFactory.createStartElement("", "", "versions"));
+        while (reader.hasNext()) {
+            XMLEvent xmlEvent = reader.nextEvent();
+            if (xmlEvent.isStartElement() && xmlEvent.asStartElement().getName().getLocalPart().equals("text")) {
+                XMLEvent text = reader.nextEvent();
+                if (!text.isCharacters()) {
+                    throw new IllegalStateException("Unexpected evet instead of characters: " + text);
+                }
+                String data = text.asCharacters().getData();
+                if (VERSION_PATTERN.matcher(data).matches()) {
+                    if (versionComparator.compare(latest, data) <= 0) {
+                        latest = data;
+                    }
+                    writer.add(eventFactory.createCharacters("\n      "));
+                    writer.add(eventFactory.createStartElement("", "", "version"));
+                    writer.add(eventFactory.createCharacters(data));
+                    writer.add(eventFactory.createEndElement("", "", "version"));
+                    reader.nextEvent(); // just get the value out of the stream (discard)
+                }
+            }
+        }
+        writer.add(eventFactory.createCharacters("\n    "));
+        writer.add(eventFactory.createEndElement("", "", "versions"));
+        writer.add(eventFactory.createCharacters("\n    "));
+        writer.add(eventFactory.createStartElement("", "", "latest"));
+        writer.add(eventFactory.createCharacters(latest));
+        writer.add(eventFactory.createEndElement("", "", "latest"));
+        writer.add(eventFactory.createCharacters("\n    "));
+        writer.add(eventFactory.createStartElement("", "", "lastUpdated"));
+        writer.add(eventFactory.createCharacters(LAST_UPDATED_FORMAT.format(LocalDateTime.now(Clock.systemUTC()))));
+        writer.add(eventFactory.createEndElement("", "", "lastUpdated"));
+        writer.add(eventFactory.createCharacters("\n  "));
+        writer.add(eventFactory.createEndElement("", "", "versioning"));
+        writer.add(eventFactory.createCharacters("\n"));
+        writer.add(eventFactory.createEndElement("", "", "metadata"));
+        writer.add(eventFactory.createEndDocument());
+        writer.flush();
+        writer.close();
+    }
+
+    public static void mergeMetadataXml(byte[] in, String version, Writer out, Comparator<String> versionComparator) throws javax.xml.stream.XMLStreamException {
+        mergeMetadataXml(new ByteArrayInputStream(in), version, out, versionComparator);
+    }
+
+    public static void mergeMetadataXml(InputStream in, String version, Writer out, Comparator<String> versionComparator) throws javax.xml.stream.XMLStreamException {
+        XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+        XMLOutputFactory outFactory = XMLOutputFactory.newInstance();
+        XMLEventFactory eventFactory = XMLEventFactory.newInstance();
+
+        XMLEventReader reader = xmlInputFactory.createXMLEventReader(in);
+        XMLEventWriter writer = outFactory.createXMLEventWriter(out);
+
+        boolean hasCurrentVersion = false;
+
+        while (reader.hasNext()) {
+            XMLEvent xmlEvent = reader.nextEvent();
+            if (xmlEvent.isStartElement() && xmlEvent.asStartElement().getName().getLocalPart().equals("lastUpdated")) {
+                writer.add(xmlEvent);
+                reader.nextEvent(); // just get the value out of the stream (discard), we'll set one ourselves:
+                writer.add(eventFactory.createCharacters(LAST_UPDATED_FORMAT.format(LocalDateTime.now(Clock.systemUTC()))));
+                writer.add(reader.nextEvent());
+                continue;
+            }
+            if (xmlEvent.isStartElement() && xmlEvent.asStartElement().getName().getLocalPart().equals("version")) {
+                writer.add(xmlEvent);
+                XMLEvent ver = reader.nextEvent();
+                if (!ver.isCharacters()) {
+                    throw new IllegalStateException("Unexpected event when reading version value: " + ver);
+                }
+                hasCurrentVersion |= ver.asCharacters().getData().equals(version);
+                writer.add(ver);
+                writer.add(reader.nextEvent());
+
+                continue;
+            }
+            if (xmlEvent.isStartElement() && xmlEvent.asStartElement().getName().getLocalPart().equals("latest")) {
+                writer.add(xmlEvent);
+                XMLEvent ver = reader.nextEvent();
+                if (!ver.isCharacters()) {
+                    throw new IllegalStateException("Unexpected event when reading version value: " + ver);
+                }
+                String data = ver.asCharacters().getData();
+                String latest = versionComparator.compare(version, data) <= 0 ? data : version;
+                writer.add(eventFactory.createCharacters(latest));
+                writer.add(reader.nextEvent());
+
+                continue;
+            }
+            if (xmlEvent.isEndElement() && xmlEvent.asEndElement().getName().getLocalPart().equals("versions") && !hasCurrentVersion) {
+                writer.add(eventFactory.createStartElement("", "", "version"));
+                writer.add(eventFactory.createCharacters(version));
+                writer.add(eventFactory.createEndElement("", "", "version"));
+            }
+            writer.add(xmlEvent);
+        }
+        writer.flush();
+        writer.close();
+        reader.close();
+    }
+}

--- a/api/jreleaser-utils/src/test/java/org/jreleaser/util/MavenMetadataTransformationUtilsTest.java
+++ b/api/jreleaser-utils/src/test/java/org/jreleaser/util/MavenMetadataTransformationUtilsTest.java
@@ -1,0 +1,194 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2025 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+class MavenMetadataTransformationUtilsTest {
+    @Test
+    void merge() throws Exception {
+        try (var sw = new StringWriter()) {
+            var projectVersion = "9.0.0-SNAPSHOT";
+            // Because of the used versions in the examples, we can rely on simple string comparator without parsing the versions:
+            MavenMetadataTransformationUtils.mergeMetadataXml(MERGE_XML.getBytes(StandardCharsets.UTF_8), projectVersion, sw, String::compareTo);
+            String xml = sw.toString();
+            Assertions.assertTrue(
+                Pattern.compile("<\\?xml version=\\\"1\\.0\\\" encoding=\\\"UTF-8\\\"\\?>\\s*<metadata>\\s*" +
+                    "<groupId>org\\.hibernate\\.orm</groupId>\\s*" +
+                    "<artifactId>hibernate-core</artifactId>\\s*" +
+                    "<versioning>\\s*" +
+                    "<latest>9\\.0\\.0-SNAPSHOT</latest>\\s*" +
+                    "<versions>\\s*" +
+                    "<version>7\\.0\\.7-SNAPSHOT</version>\\s*" +
+                    "<version>9\\.0\\.0-SNAPSHOT</version>\\s*" +
+                    "</versions>\\s*" +
+                    "<lastUpdated>\\d{14}</lastUpdated>\\s*" + // the date will change all the time, and no point in dragging a fixed clock into this, just to test things.
+                    "</versioning>\\s*</metadata>\\s*").matcher(
+                    xml).matches());
+        } catch (IOException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void mergedXmlCanBeReprocessed() throws Exception {
+        String xml;
+        try (var sw = new StringWriter()) {
+            var projectVersion = "8.0.0-SNAPSHOT";
+            // Because of the used versions in the examples, we can rely on simple string comparator without parsing the versions:
+            MavenMetadataTransformationUtils.mergeMetadataXml(MERGE_XML.getBytes(StandardCharsets.UTF_8), projectVersion, sw, String::compareTo);
+             xml = sw.toString();
+        }
+        try (var sw = new StringWriter()) {
+            // now pass the processed xml as if we've uploaded it already, and are processing it on the next release
+            var projectVersion = "9.0.0-SNAPSHOT";
+            MavenMetadataTransformationUtils.mergeMetadataXml(xml.getBytes(StandardCharsets.UTF_8), projectVersion, sw, String::compareTo);
+            xml = sw.toString();
+
+            Assertions.assertTrue(
+                Pattern.compile("<\\?xml version=\\\"1\\.0\\\" encoding=\\\"UTF-8\\\"\\?>\\s*<metadata>\\s*" +
+                    "<groupId>org\\.hibernate\\.orm</groupId>\\s*" +
+                    "<artifactId>hibernate-core</artifactId>\\s*" +
+                    "<versioning>\\s*" +
+                    "<latest>9\\.0\\.0-SNAPSHOT</latest>\\s*" +
+                    "<versions>\\s*" +
+                    "<version>7\\.0\\.7-SNAPSHOT</version>\\s*" +
+                    "<version>8\\.0\\.0-SNAPSHOT</version>\\s*" +
+                    "<version>9\\.0\\.0-SNAPSHOT</version>\\s*" +
+                    "</versions>\\s*" +
+                    "<lastUpdated>\\d{14}</lastUpdated>\\s*" + // the date will change all the time, and no point in dragging a fixed clock into this, just to test things.
+                    "</versioning>\\s*</metadata>\\s*").matcher(
+                    xml).matches());
+        } catch (IOException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void recreate() throws Exception {
+        var projectVersion = "9.0.0-SNAPSHOT";
+        var groupId = "org.hibernate.orm";
+        var artifactId = "hibernate-core";
+        try (var sw = new StringWriter()) {
+            // Because of the used versions in the examples, we can rely on simple string comparator without parsing the versions:
+            MavenMetadataTransformationUtils.recreateMetadataXml(RECREATE_XML.getBytes(StandardCharsets.UTF_8), projectVersion, groupId, artifactId, sw, String::compareTo);
+            String xml = sw.toString();
+            Assertions.assertTrue(
+                Pattern.compile("<\\?xml version=\\\"1\\.0\\\" encoding=\\\"UTF-8\\\"\\?>\\s*<metadata>\\s*" +
+                    "<groupId>org\\.hibernate\\.orm</groupId>\\s*" +
+                    "<artifactId>hibernate-core</artifactId>\\s*" +
+                    "<versioning>\\s*<versions>\\s*" +
+                    "<version>6\\.4\\.0-SNAPSHOT</version>\\s*" +
+                    "<version>6\\.4\\.9-SNAPSHOT</version>\\s*" +
+                    "<version>6\\.2\\.13-SNAPSHOT</version>\\s*" +
+                    "<version>6\\.5\\.0-SNAPSHOT</version>\\s*" +
+                    "<version>6\\.4\\.7-SNAPSHOT</version>\\s*" +
+                    "<version>6\\.3\\.3-SNAPSHOT</version>\\s*" +
+                    "</versions>\\s*" +
+                    "<latest>9\\.0\\.0-SNAPSHOT</latest>\\s*" +
+                    "<lastUpdated>\\d{14}</lastUpdated>\\s*" + // the date will change all the time, and no point in dragging a fixed clock into this, just to test things.
+                    "</versioning>\\s*</metadata>\\s*").matcher(
+                    xml).matches());
+        } catch (IOException e) {
+            fail(e);
+        }
+    }
+
+    private static final String MERGE_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+        "<metadata>\n" +
+        "  <groupId>org.hibernate.orm</groupId>\n" +
+        "  <artifactId>hibernate-core</artifactId>\n" +
+        "  <versioning>\n" +
+        "    <latest>7.0.7-SNAPSHOT</latest>\n" +
+        "    <versions>\n" +
+        "      <version>7.0.7-SNAPSHOT</version>\n" +
+        "    </versions>\n" +
+        "    <lastUpdated>20250429074943</lastUpdated>\n" +
+        "  </versioning>\n" +
+        "</metadata>\n";
+
+    private static final String RECREATE_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+        "<content>\n" +
+        "  <data>\n" +
+        "    <content-item>\n" +
+        "      <resourceURI>https://oss.sonatype.org/service/local/repositories/snapshots/content/org/hibernate/orm/hibernate-core/6.4.0-SNAPSHOT/</resourceURI>\n" +
+        "      <relativePath>/org/hibernate/orm/hibernate-core/6.4.0-SNAPSHOT/</relativePath>\n" +
+        "      <text>6.4.0-SNAPSHOT</text>\n" +
+        "      <leaf>false</leaf>\n" +
+        "      <lastModified>2024-09-30 07:38:24.321 UTC</lastModified>\n" +
+        "      <sizeOnDisk>-1</sizeOnDisk>\n" +
+        "    </content-item>\n" +
+        "    <content-item>\n" +
+        "      <resourceURI>https://oss.sonatype.org/service/local/repositories/snapshots/content/org/hibernate/orm/hibernate-core/maven-metadata.xml.sha512</resourceURI>\n" +
+        "      <relativePath>/org/hibernate/orm/hibernate-core/maven-metadata.xml.sha512</relativePath>\n" +
+        "      <text>maven-metadata.xml.sha512</text>\n" +
+        "      <leaf>true</leaf>\n" +
+        "      <lastModified>2025-04-26 18:38:56.885 UTC</lastModified>\n" +
+        "      <sizeOnDisk>128</sizeOnDisk>\n" +
+        "    </content-item>\n" +
+        "    <content-item>\n" +
+        "      <resourceURI>https://oss.sonatype.org/service/local/repositories/snapshots/content/org/hibernate/orm/hibernate-core/6.4.9-SNAPSHOT/</resourceURI>\n" +
+        "      <relativePath>/org/hibernate/orm/hibernate-core/6.4.9-SNAPSHOT/</relativePath>\n" +
+        "      <text>6.4.9-SNAPSHOT</text>\n" +
+        "      <leaf>false</leaf>\n" +
+        "      <lastModified>2024-09-30 07:38:24.609 UTC</lastModified>\n" +
+        "      <sizeOnDisk>-1</sizeOnDisk>\n" +
+        "    </content-item>\n" +
+        "    <content-item>\n" +
+        "      <resourceURI>https://oss.sonatype.org/service/local/repositories/snapshots/content/org/hibernate/orm/hibernate-core/6.2.13-SNAPSHOT/</resourceURI>\n" +
+        "      <relativePath>/org/hibernate/orm/hibernate-core/6.2.13-SNAPSHOT/</relativePath>\n" +
+        "      <text>6.2.13-SNAPSHOT</text>\n" +
+        "      <leaf>false</leaf>\n" +
+        "      <lastModified>2024-09-30 07:38:24.849 UTC</lastModified>\n" +
+        "      <sizeOnDisk>-1</sizeOnDisk>\n" +
+        "    </content-item>\n" +
+        "    <content-item>\n" +
+        "      <resourceURI>https://oss.sonatype.org/service/local/repositories/snapshots/content/org/hibernate/orm/hibernate-core/6.5.0-SNAPSHOT/</resourceURI>\n" +
+        "      <relativePath>/org/hibernate/orm/hibernate-core/6.5.0-SNAPSHOT/</relativePath>\n" +
+        "      <text>6.5.0-SNAPSHOT</text>\n" +
+        "      <leaf>false</leaf>\n" +
+        "      <lastModified>2024-09-30 07:38:25.413 UTC</lastModified>\n" +
+        "      <sizeOnDisk>-1</sizeOnDisk>\n" +
+        "    </content-item>\n" +
+        "    <content-item>\n" +
+        "      <resourceURI>https://oss.sonatype.org/service/local/repositories/snapshots/content/org/hibernate/orm/hibernate-core/6.4.7-SNAPSHOT/</resourceURI>\n" +
+        "      <relativePath>/org/hibernate/orm/hibernate-core/6.4.7-SNAPSHOT/</relativePath>\n" +
+        "      <text>6.4.7-SNAPSHOT</text>\n" +
+        "      <leaf>false</leaf>\n" +
+        "      <lastModified>2024-09-30 07:38:25.717 UTC</lastModified>\n" +
+        "      <sizeOnDisk>-1</sizeOnDisk>\n" +
+        "    </content-item>\n" +
+        "    <content-item>\n" +
+        "      <resourceURI>https://oss.sonatype.org/service/local/repositories/snapshots/content/org/hibernate/orm/hibernate-core/6.3.3-SNAPSHOT/</resourceURI>\n" +
+        "      <relativePath>/org/hibernate/orm/hibernate-core/6.3.3-SNAPSHOT/</relativePath>\n" +
+        "      <text>6.3.3-SNAPSHOT</text>\n" +
+        "      <leaf>false</leaf>\n" +
+        "      <lastModified>2024-09-30 07:38:43.942 UTC</lastModified>\n" +
+        "      <sizeOnDisk>-1</sizeOnDisk>\n" +
+        "    </content-item>\n" +
+        "  </data>\n" +
+        "</content>\n";
+}

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/deploy/maven/AbstractMavenDeployer.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/deploy/maven/AbstractMavenDeployer.java
@@ -21,14 +21,17 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.jreleaser.model.Http;
 import org.jreleaser.model.internal.common.AbstractActivatable;
 import org.jreleaser.model.internal.common.ExtraProperties;
+import org.jreleaser.model.spi.deploy.maven.Deployable;
 import org.jreleaser.mustache.TemplateContext;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.jreleaser.model.Constants.HIDE;
@@ -324,6 +327,16 @@ public abstract class AbstractMavenDeployer<S extends AbstractMavenDeployer<S, A
     @Override
     public void setSnapshotSupported(Boolean snapshotSupported) {
         this.snapshotSupported = snapshotSupported;
+    }
+
+    @Override
+    public org.jreleaser.model.api.deploy.maven.MavenDeployer.MavenMetadataTransformationMode getMavenMetadataTransformationMode() {
+        return org.jreleaser.model.api.deploy.maven.MavenDeployer.MavenMetadataTransformationMode.DISABLED;
+    }
+
+    @Override
+    public Optional<URI> getMavenMetadataUrl(Deployable deployable) {
+        return Optional.empty();
     }
 
     @Override

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/deploy/maven/MavenDeployer.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/deploy/maven/MavenDeployer.java
@@ -23,11 +23,14 @@ import org.jreleaser.model.internal.common.AbstractModelObject;
 import org.jreleaser.model.internal.common.Domain;
 import org.jreleaser.model.internal.common.TimeoutAware;
 import org.jreleaser.model.internal.deploy.Deployer;
+import org.jreleaser.model.spi.deploy.maven.Deployable;
 import org.jreleaser.mustache.TemplateContext;
 
+import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static java.util.Collections.unmodifiableMap;
@@ -108,6 +111,10 @@ public interface MavenDeployer<A extends org.jreleaser.model.api.deploy.maven.Ma
     List<String> keysFor(String property);
 
     void setSnapshotSupported(Boolean snapshotSupported);
+
+    org.jreleaser.model.api.deploy.maven.MavenDeployer.MavenMetadataTransformationMode getMavenMetadataTransformationMode();
+
+    Optional<URI> getMavenMetadataUrl(Deployable deployable);
 
     public final class ArtifactOverride extends AbstractModelObject<ArtifactOverride> implements Domain {
         private static final long serialVersionUID = 8057060716591206147L;

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/spi/deploy/maven/Deployable.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/spi/deploy/maven/Deployable.java
@@ -18,6 +18,7 @@
 package org.jreleaser.model.spi.deploy.maven;
 
 import org.jreleaser.mustache.TemplateContext;
+import org.jreleaser.version.SemanticVersion;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -284,5 +285,32 @@ public class Deployable implements Comparable<Deployable> {
 
     public boolean isMavenMetadata() {
         return filename.endsWith(MAVEN_METADATA_XML);
+    }
+
+    public boolean isVersionSpecificMavenMetadata() {
+        if (!isMavenMetadata()) return false;
+        try {
+            SemanticVersion.of(Paths.get(path).getFileName().toString());
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Deployable{" +
+            "stagingRepository='" + stagingRepository + '\'' +
+            ", path='" + path + '\'' +
+            ", filename='" + filename + '\'' +
+            ", groupId='" + groupId + '\'' +
+            ", artifactId='" + artifactId + '\'' +
+            ", version='" + version + '\'' +
+            ", classifier='" + classifier + '\'' +
+            ", extension='" + extension + '\'' +
+            ", packaging='" + packaging + '\'' +
+            ", relocated=" + relocated +
+            ", snapshot=" + snapshot +
+            '}';
     }
 }

--- a/sdks/jreleaser-java-sdk-commons/jreleaser-java-sdk-commons.gradle
+++ b/sdks/jreleaser-java-sdk-commons/jreleaser-java-sdk-commons.gradle
@@ -39,4 +39,5 @@ dependencies {
     api "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     api "io.github.openfeign.form:feign-form:$feignFormVersion"
     api "commons-io:commons-io:$commonsIoVersion"
+    api "dev.failsafe:failsafe:$failsafeVersion"
 }


### PR DESCRIPTION
This one is from the discussion at https://github.com/jreleaser/jreleaser/discussions/1862

I'll open it as a draft as it only adds this to nexus2 for now, and I wanted to get some early feedback if I'm going in the right direction here, as I'm unfamiliar with the code 🙈 😃 (will create a GH issue once this is in a more ready shape)

- I see that not all maven deployers have the snapshot URLs, and I'm also not familiar with them, so my thinking here was that if we add the "merge" logic to the `AbstractMavenDeployer` we could use the optional URL for the metadata, and those actual deployers that don't support the feature would always return the `DISABLED` transformation mode + empty optional links as a second precaution. 
- I've tried to keep most of the changes to the spi/internal packages. 
- Not sure if it is ok to add the `dev.failsafe:failsafe` to `jreleaser-java-sdk-commons.gradle`. I initially wanted to have the download logic inside the specific deployers (where the dependency is already present), but I got lost a bit (how to cleanly pass the downloaded XML back to the `AbstractMavenDeployer`), and hence, this is where I ended up so far. 
- I've hardcoded the retry "policy" for the XML downloads as I wasn't sure if that's something that would be much valuable for the user to configure. 
- There are no docs updates for now, but once I figure this out, I'll see what/where to add to the docs as well.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
