### PR TITLE
fix(gradle): add support for blank gpg passphrase

### DIFF
--- a/api/jreleaser-resource-bundle/src/main/resources/org/jreleaser/bundle/Messages.properties
+++ b/api/jreleaser-resource-bundle/src/main/resources/org/jreleaser/bundle/Messages.properties
@@ -160,6 +160,7 @@ signing.file.newer                   = {} is newer than {}
 signing.check.published.key          = Checking if key {} has been published
 signing.key.published                = Key {} was found as published
 signing.key.not.published            = Key {} was NOT found as published
+signing.passphrase.blank             = Passphrase is blank. In case a passphrase is needed, you can configure a value using the {}, or define a System property {}, or define a {} environment variable, or define a key/value pair in {} with a key named {}
 signing.public.key.expiration.date   = Signing key {} expires at {}
 signing.public.key.no.expiration.date = Signing key {} does not expire
 ERROR_signing_verify_file            = Could not verify file {} with signature {}


### PR DESCRIPTION
<!-- The issue this PR addresses -->
<!-- Please reference the issue this PR solves -->
Fixes #1883 

### Context
<!-- What problem does this change address? -->
<!-- Link to relevant issues or discussions here -->
GPG private keys are not always protected by a passphrase. Jreleaser should support unprotected keys.

### Testing

I tried it both with a passphrase-protected key and an unprotected key, and it works for me.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
