### PR TITLE
fix(mavencentral): show clear error messages for 401/403 (fixes #1922)

### DIFF
--- a/api/jreleaser-resource-bundle/src/main/resources/org/jreleaser/bundle/Messages.properties
+++ b/api/jreleaser-resource-bundle/src/main/resources/org/jreleaser/bundle/Messages.properties
@@ -29,6 +29,9 @@ not = not
 set.to = {} set to {}
 
 ERROR_unexpected_error = Unexpected error
+ERROR_unauthorized = Unauthorized error check your Maven Central credentials or token
+ERROR_forbidden = Forbidden error does not have permission to perform the action
+
 ERROR_unsupported_platform_override = Unsupported platform '{}', using '{}' instead
 
 ERROR_extension_manager_load                      = Failed to load ExtensionManager

--- a/api/jreleaser-resource-bundle/src/main/resources/org/jreleaser/bundle/Messages.properties
+++ b/api/jreleaser-resource-bundle/src/main/resources/org/jreleaser/bundle/Messages.properties
@@ -29,8 +29,8 @@ not = not
 set.to = {} set to {}
 
 ERROR_unexpected_error = Unexpected error
-ERROR_unauthorized = Unauthorized error check your Maven Central credentials or token
-ERROR_forbidden = Forbidden error does not have permission to perform the action
+ERROR_maven_central_unauthorized = Unauthorized. Please check credentials for {}
+ERROR_maven_central_forbidden = Forbidden. Operation not allowed
 
 ERROR_unsupported_platform_override = Unsupported platform '{}', using '{}' instead
 

--- a/sdks/jreleaser-mavencentral-java-sdk/jreleaser-mavencentral-java-sdk.gradle
+++ b/sdks/jreleaser-mavencentral-java-sdk/jreleaser-mavencentral-java-sdk.gradle
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 dependencies {
+    testImplementation(project(":jreleaser-logger-api"))
     compileOnly "org.kordamp.jipsy:jipsy-annotations:${jipsyVersion}"
     annotationProcessor "org.kordamp.jipsy:jipsy-processor:${jipsyVersion}"
 

--- a/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/MavenCentral.java
+++ b/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/MavenCentral.java
@@ -17,33 +17,11 @@
  */
 package org.jreleaser.sdk.mavencentral;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import dev.failsafe.Failsafe;
-import dev.failsafe.RetryPolicy;
-import dev.failsafe.function.CheckedPredicate;
-import dev.failsafe.function.CheckedSupplier;
-import feign.FeignException;
-import feign.Response;
-import feign.RetryableException;
-import feign.codec.DecodeException;
-import feign.codec.Decoder;
-import feign.codec.ErrorDecoder;
-import feign.form.FormData;
-import feign.jackson.JacksonDecoder;
-import org.apache.commons.io.IOUtils;
-import org.jreleaser.bundle.RB;
-import org.jreleaser.logging.JReleaserLogger;
-import org.jreleaser.model.Http;
-import org.jreleaser.model.api.JReleaserContext;
-import org.jreleaser.model.spi.deploy.maven.Deployable;
-import org.jreleaser.mustache.Templates;
-import org.jreleaser.sdk.commons.ClientUtils;
-import org.jreleaser.sdk.commons.feign.TokenAuthRequestInterceptor;
-import org.jreleaser.sdk.mavencentral.api.Deployment;
-import org.jreleaser.sdk.mavencentral.api.MavenCentralAPI;
-import org.jreleaser.sdk.mavencentral.api.MavenCentralAPIException;
-import org.jreleaser.sdk.mavencentral.api.State;
+import static java.lang.System.lineSeparator;
+import static java.util.Objects.requireNonNull;
+import static org.jreleaser.util.IoUtils.newInputStreamReader;
+import static org.jreleaser.util.StringUtils.isNotBlank;
+import static org.jreleaser.util.StringUtils.requireNonBlank;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -59,11 +37,35 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
-import static java.lang.System.lineSeparator;
-import static java.util.Objects.requireNonNull;
-import static org.jreleaser.util.IoUtils.newInputStreamReader;
-import static org.jreleaser.util.StringUtils.isNotBlank;
-import static org.jreleaser.util.StringUtils.requireNonBlank;
+import org.apache.commons.io.IOUtils;
+import org.jreleaser.bundle.RB;
+import org.jreleaser.logging.JReleaserLogger;
+import org.jreleaser.model.Http;
+import org.jreleaser.model.api.JReleaserContext;
+import org.jreleaser.model.spi.deploy.maven.Deployable;
+import org.jreleaser.mustache.Templates;
+import org.jreleaser.sdk.commons.ClientUtils;
+import org.jreleaser.sdk.commons.feign.TokenAuthRequestInterceptor;
+import org.jreleaser.sdk.mavencentral.api.Deployment;
+import org.jreleaser.sdk.mavencentral.api.MavenCentralAPI;
+import org.jreleaser.sdk.mavencentral.api.MavenCentralAPIException;
+import org.jreleaser.sdk.mavencentral.api.State;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import dev.failsafe.Failsafe;
+import dev.failsafe.RetryPolicy;
+import dev.failsafe.function.CheckedPredicate;
+import dev.failsafe.function.CheckedSupplier;
+import feign.FeignException;
+import feign.Response;
+import feign.RetryableException;
+import feign.codec.DecodeException;
+import feign.codec.Decoder;
+import feign.codec.ErrorDecoder;
+import feign.form.FormData;
+import feign.jackson.JacksonDecoder;
 
 /**
  * @author Andres Almiray
@@ -78,15 +80,15 @@ public class MavenCentral {
     private final Retrier retrier;
 
     public MavenCentral(JReleaserContext context,
-                        String apiHost,
-                        Http.Authorization authorization,
-                        String username,
-                        String password,
-                        int connectTimeout,
-                        int readTimeout,
-                        boolean dryrun,
-                        int retryDelay,
-                        int maxRetries) {
+            String apiHost,
+            Http.Authorization authorization,
+            String username,
+            String password,
+            int connectTimeout,
+            int readTimeout,
+            boolean dryrun,
+            int retryDelay,
+            int maxRetries) {
         requireNonBlank(apiHost, "'apiHost' must not be blank");
         requireNonNull(authorization, "'authorization' must not be blank");
 
@@ -102,10 +104,10 @@ public class MavenCentral {
         }
 
         this.api = ClientUtils.builder(context, connectTimeout, readTimeout)
-            .decoder(new MavenCentralDecoder())
-            .requestInterceptor(authRequestInterceptor)
-            .errorDecoder(new MavenCentralErrorDecoder(context.getLogger()))
-            .target(MavenCentralAPI.class, apiHost);
+                .decoder(new MavenCentralDecoder())
+                .requestInterceptor(authRequestInterceptor)
+                .errorDecoder(new MavenCentralErrorDecoder(context.getLogger()))
+                .target(MavenCentralAPI.class, apiHost);
     }
 
     public boolean artifactExists(Deployable deployable, String verifyUrl) {
@@ -113,8 +115,8 @@ public class MavenCentral {
             verifyUrl = Templates.resolveTemplate(verifyUrl, deployable.props());
             if (ClientUtils.head(context.getLogger(), verifyUrl, connectTimeout, readTimeout)) {
                 context.getLogger().warn(" ! " + RB.$("nexus.deploy.artifact.exists",
-                    deployable.getDeployPath(),
-                    deployable.getLocalPath().getFileName().toString()));
+                        deployable.getDeployPath(),
+                        deployable.getLocalPath().getFileName().toString()));
                 return true;
             }
         }
@@ -150,7 +152,8 @@ public class MavenCentral {
 
     private void wrap(MavenCentralOperation operation) throws MavenCentralException {
         try {
-            if (!dryrun) operation.execute();
+            if (!dryrun)
+                operation.execute();
         } catch (MavenCentralException e) {
             context.getLogger().trace(e);
             throw e;
@@ -178,13 +181,14 @@ public class MavenCentral {
     private void waitForState(String deploymentId, boolean checkTimeout, State... states) throws MavenCentralException {
         context.getLogger().debug(RB.$("maven.central.wait.deployment.state", deploymentId, Arrays.asList(states)));
 
-        Boolean[] timeout = new Boolean[]{false};
+        Boolean[] timeout = new Boolean[] { false };
         Optional<Deployment> deployment = retrier.retry(o -> o.map(Deployment::isTransitioning).orElse(false),
-            () -> status(deploymentId),
-            states[0] != State.PUBLISHED? () -> {}: () -> {
-                context.getLogger().warn(RB.$("WARN_maven_central_publication_timeout", deploymentId));
-                timeout[0] = true;
-            });
+                () -> status(deploymentId),
+                states[0] != State.PUBLISHED ? () -> {
+                } : () -> {
+                    context.getLogger().warn(RB.$("WARN_maven_central_publication_timeout", deploymentId));
+                    timeout[0] = true;
+                });
 
         if (checkTimeout && timeout[0]) {
             return;
@@ -197,7 +201,8 @@ public class MavenCentral {
 
             if (Arrays.binarySearch(states, deployment.get().getDeploymentState()) < 0) {
                 Set<String> messages = resolveErrorMessages(deployment.get());
-                String title = RB.$("maven.central.wait.deployment.invalid.state", deploymentId, Arrays.asList(states), deployment.get().getDeploymentState());
+                String title = RB.$("maven.central.wait.deployment.invalid.state", deploymentId, Arrays.asList(states),
+                        deployment.get().getDeploymentState());
                 if (!messages.isEmpty()) {
                     throw new MavenCentralException(title + lineSeparator() + String.join(lineSeparator(), messages));
                 } else {
@@ -235,30 +240,33 @@ public class MavenCentral {
         }
 
         public <R> R retry(CheckedPredicate<R> stopFunction, CheckedSupplier<R> retriableOperation) {
-            return retry(stopFunction, retriableOperation, () -> {});
+            return retry(stopFunction, retriableOperation, () -> {
+            });
         }
 
-        public <R> R retry(CheckedPredicate<R> stopFunction, CheckedSupplier<R> retriableOperation, Runnable retryHandler) {
+        public <R> R retry(CheckedPredicate<R> stopFunction, CheckedSupplier<R> retriableOperation,
+                Runnable retryHandler) {
             final int maxAttempts = maxRetries + 1;
 
             RetryPolicy<R> policy = RetryPolicy.<R>builder()
-                .handle(IllegalStateException.class)
-                .handleIf(exception -> {
-                    if (exception instanceof MavenCentralAPIException) {
-                        MavenCentralAPIException mavenCentralException = (MavenCentralAPIException) exception;
-                        return !mavenCentralException.isUnauthorized();
-                    }
+                    .handle(IllegalStateException.class)
+                    .handleIf(exception -> {
+                        if (exception instanceof MavenCentralAPIException) {
+                            MavenCentralAPIException mavenCentralException = (MavenCentralAPIException) exception;
+                            return !mavenCentralException.isUnauthorized();
+                        }
 
-                    return false;
-                })
-                .handleResultIf(stopFunction)
-                .withDelay(Duration.ofSeconds(delay))
-                .withMaxRetries(maxRetries)
-                .onRetriesExceeded(listener -> retryHandler.run())
-                .onFailedAttempt(event -> {
-                    logger.info(RB.$("nexus.retry.attempt"), event.getAttemptCount(), maxAttempts);
-                    logger.debug(RB.$("nexus.retry.failed.attempt", event.getAttemptCount(), maxAttempts, event.getLastResult()), event.getLastException());
-                }).build();
+                        return false;
+                    })
+                    .handleResultIf(stopFunction)
+                    .withDelay(Duration.ofSeconds(delay))
+                    .withMaxRetries(maxRetries)
+                    .onRetriesExceeded(listener -> retryHandler.run())
+                    .onFailedAttempt(event -> {
+                        logger.info(RB.$("nexus.retry.attempt"), event.getAttemptCount(), maxAttempts);
+                        logger.debug(RB.$("nexus.retry.failed.attempt", event.getAttemptCount(), maxAttempts,
+                                event.getLastResult()), event.getLastException());
+                    }).build();
 
             return Failsafe.with(policy).get(retriableOperation);
         }
@@ -292,21 +300,20 @@ public class MavenCentral {
                 }
 
                 return new RetryableException(
-                    response.status(),
-                    response.reason(),
-                    response.request().httpMethod(),
-                    (Long) null,
-                    response.request());
+                        response.status(),
+                        response.reason(),
+                        response.request().httpMethod(),
+                        (Long) null,
+                        response.request());
             }
 
             // Handle Unauthorized error
             if (response.status() == 401) {
-                return new MavenCentralAPIException(401, "❌ Unauthorized (401): Please check your Maven Central credentials or token.", response.headers());
+                return new MavenCentralAPIException(401, RB.$("ERROR_unauthorized"), response.headers());
             }
-
             // Handle Forbidden error
             if (response.status() == 403) {
-                return new MavenCentralAPIException(403, "❌ Forbidden (403): You don't have permission to upload to this repository.", response.headers());
+                return new MavenCentralAPIException(403, RB.$("ERROR_forbidden"), response.headers());
             }
 
             return new MavenCentralAPIException(response.status(), response.reason(), response.headers());
@@ -315,7 +322,7 @@ public class MavenCentral {
 
     static class MavenCentralDecoder implements Decoder {
         private final JacksonDecoder json = new JacksonDecoder(new ObjectMapper()
-            .registerModule(new JavaTimeModule()));
+                .registerModule(new JavaTimeModule()));
 
         @Override
         public Object decode(Response response, Type type) throws IOException, DecodeException, FeignException {

--- a/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/MavenCentral.java
+++ b/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/MavenCentral.java
@@ -299,6 +299,16 @@ public class MavenCentral {
                     response.request());
             }
 
+            // Handle Unauthorized error
+            if (response.status() == 401) {
+                return new MavenCentralAPIException(401, "❌ Unauthorized (401): Please check your Maven Central credentials or token.", response.headers());
+            }
+
+            // Handle Forbidden error
+            if (response.status() == 403) {
+                return new MavenCentralAPIException(403, "❌ Forbidden (403): You don't have permission to upload to this repository.", response.headers());
+            }
+
             return new MavenCentralAPIException(response.status(), response.reason(), response.headers());
         }
     }

--- a/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/MavenCentralMavenDeployer.java
+++ b/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/MavenCentralMavenDeployer.java
@@ -97,7 +97,7 @@ public class MavenCentralMavenDeployer extends AbstractMavenDeployer<org.jreleas
             deployer.getAuthorization(),
             deployer.getUsername(), deployer.getPassword(),
             deployer.getConnectTimeout(), deployer.getReadTimeout(), context.isDryrun(),
-            deployer.getRetryDelay(), deployer.getMaxRetries());
+            deployer.getRetryDelay(), deployer.getMaxRetries(), deployer.getName());
 
         context.getAdditionalProperties().put(prefix("namespace"), deployer.getNamespace());
         Deployment deployment = null;

--- a/sdks/jreleaser-mavencentral-java-sdk/src/test/java/org/jreleaser/sdk/mavencentral/MavenCentralErrorDecoderTest.java
+++ b/sdks/jreleaser-mavencentral-java-sdk/src/test/java/org/jreleaser/sdk/mavencentral/MavenCentralErrorDecoderTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Collections;
 
 import org.jreleaser.logging.JReleaserLogger;
+import org.jreleaser.logging.SimpleJReleaserLoggerAdapter;
 import org.jreleaser.sdk.mavencentral.api.MavenCentralAPIException;
 import org.junit.jupiter.api.Test;
 
@@ -14,108 +15,7 @@ import feign.Response;
 import feign.RetryableException;
 
 class MavenCentralErrorDecoderTest {
-    private final JReleaserLogger logger = new JReleaserLogger() {
-        @Override
-        public java.io.PrintWriter getTracer() {
-            return null;
-        }
-
-        @Override
-        public void close() {
-        }
-
-        @Override
-        public void reset() {
-        }
-
-        @Override
-        public void increaseIndent() {
-        }
-
-        @Override
-        public void decreaseIndent() {
-        }
-
-        @Override
-        public void setPrefix(String prefix) {
-        }
-
-        @Override
-        public void restorePrefix() {
-        }
-
-        @Override
-        public void plain(String message) {
-        }
-
-        @Override
-        public void debug(String message) {
-        }
-
-        @Override
-        public void info(String message) {
-        }
-
-        @Override
-        public void warn(String message) {
-        }
-
-        @Override
-        public void error(String message) {
-        }
-
-        @Override
-        public void trace(String message) {
-        }
-
-        @Override
-        public void plain(String message, Object... args) {
-        }
-
-        @Override
-        public void debug(String message, Object... args) {
-        }
-
-        @Override
-        public void info(String message, Object... args) {
-        }
-
-        @Override
-        public void warn(String message, Object... args) {
-        }
-
-        @Override
-        public void error(String message, Object... args) {
-        }
-
-        @Override
-        public void plain(String message, Throwable throwable) {
-        }
-
-        @Override
-        public void debug(String message, Throwable throwable) {
-        }
-
-        @Override
-        public void info(String message, Throwable throwable) {
-        }
-
-        @Override
-        public void warn(String message, Throwable throwable) {
-        }
-
-        @Override
-        public void error(String message, Throwable throwable) {
-        }
-
-        @Override
-        public void trace(String message, Throwable throwable) {
-        }
-
-        @Override
-        public void trace(Throwable throwable) {
-        }
-    };
+    private final JReleaserLogger logger = new SimpleJReleaserLoggerAdapter();
 
     private Response buildResponse(int status, String reason) {
         Request request = Request.create(Request.HttpMethod.GET, "http://localhost", Collections.emptyMap(), null,

--- a/sdks/jreleaser-mavencentral-java-sdk/src/test/java/org/jreleaser/sdk/mavencentral/MavenCentralErrorDecoderTest.java
+++ b/sdks/jreleaser-mavencentral-java-sdk/src/test/java/org/jreleaser/sdk/mavencentral/MavenCentralErrorDecoderTest.java
@@ -1,3 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2025 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jreleaser.sdk.mavencentral;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,17 +47,19 @@ class MavenCentralErrorDecoderTest {
 
     @Test
     void returnsUnauthorizedExceptionFor401() {
-        MavenCentral.MavenCentralErrorDecoder decoder = new MavenCentral.MavenCentralErrorDecoder(logger);
+        MavenCentral.MavenCentralErrorDecoder decoder = new MavenCentral.MavenCentralErrorDecoder(logger, "testDeployer");
         Response response = buildResponse(401, "Unauthorized");
         Exception ex = decoder.decode("method", response);
         assertThat(ex).isInstanceOf(MavenCentralAPIException.class);
         assertThat(((MavenCentralAPIException) ex).getStatus()).isEqualTo(401);
         assertThat(ex.getMessage()).contains("Unauthorized");
+        assertThat(ex.getMessage()).contains("deploy.maven.testDeployer");
     }
+
 
     @Test
     void returnsForbiddenExceptionFor403() {
-        MavenCentral.MavenCentralErrorDecoder decoder = new MavenCentral.MavenCentralErrorDecoder(logger);
+        MavenCentral.MavenCentralErrorDecoder decoder = new MavenCentral.MavenCentralErrorDecoder(logger, "testDeployer");
         Response response = buildResponse(403, "Forbidden");
         Exception ex = decoder.decode("method", response);
         assertThat(ex).isInstanceOf(MavenCentralAPIException.class);
@@ -48,17 +67,19 @@ class MavenCentralErrorDecoderTest {
         assertThat(ex.getMessage()).contains("Forbidden");
     }
 
+
     @Test
     void returnsRetryableExceptionFor500() {
-        MavenCentral.MavenCentralErrorDecoder decoder = new MavenCentral.MavenCentralErrorDecoder(logger);
+        MavenCentral.MavenCentralErrorDecoder decoder = new MavenCentral.MavenCentralErrorDecoder(logger, "testDeployer");
         Response response = buildResponse(500, "Internal Server Error");
         Exception ex = decoder.decode("method", response);
         assertThat(ex).isInstanceOf(RetryableException.class);
     }
 
+
     @Test
     void returnsDefaultExceptionForOtherStatus() {
-        MavenCentral.MavenCentralErrorDecoder decoder = new MavenCentral.MavenCentralErrorDecoder(logger);
+        MavenCentral.MavenCentralErrorDecoder decoder = new MavenCentral.MavenCentralErrorDecoder(logger, "testDeployer");
         Response response = buildResponse(404, "Not Found");
         Exception ex = decoder.decode("method", response);
         assertThat(ex).isInstanceOf(MavenCentralAPIException.class);

--- a/sdks/jreleaser-mavencentral-java-sdk/src/test/java/org/jreleaser/sdk/mavencentral/MavenCentralErrorDecoderTest.java
+++ b/sdks/jreleaser-mavencentral-java-sdk/src/test/java/org/jreleaser/sdk/mavencentral/MavenCentralErrorDecoderTest.java
@@ -1,0 +1,168 @@
+package org.jreleaser.sdk.mavencentral;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+
+import org.jreleaser.logging.JReleaserLogger;
+import org.jreleaser.sdk.mavencentral.api.MavenCentralAPIException;
+import org.junit.jupiter.api.Test;
+
+import feign.Request;
+import feign.RequestTemplate;
+import feign.Response;
+import feign.RetryableException;
+
+class MavenCentralErrorDecoderTest {
+    private final JReleaserLogger logger = new JReleaserLogger() {
+        @Override
+        public java.io.PrintWriter getTracer() {
+            return null;
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public void reset() {
+        }
+
+        @Override
+        public void increaseIndent() {
+        }
+
+        @Override
+        public void decreaseIndent() {
+        }
+
+        @Override
+        public void setPrefix(String prefix) {
+        }
+
+        @Override
+        public void restorePrefix() {
+        }
+
+        @Override
+        public void plain(String message) {
+        }
+
+        @Override
+        public void debug(String message) {
+        }
+
+        @Override
+        public void info(String message) {
+        }
+
+        @Override
+        public void warn(String message) {
+        }
+
+        @Override
+        public void error(String message) {
+        }
+
+        @Override
+        public void trace(String message) {
+        }
+
+        @Override
+        public void plain(String message, Object... args) {
+        }
+
+        @Override
+        public void debug(String message, Object... args) {
+        }
+
+        @Override
+        public void info(String message, Object... args) {
+        }
+
+        @Override
+        public void warn(String message, Object... args) {
+        }
+
+        @Override
+        public void error(String message, Object... args) {
+        }
+
+        @Override
+        public void plain(String message, Throwable throwable) {
+        }
+
+        @Override
+        public void debug(String message, Throwable throwable) {
+        }
+
+        @Override
+        public void info(String message, Throwable throwable) {
+        }
+
+        @Override
+        public void warn(String message, Throwable throwable) {
+        }
+
+        @Override
+        public void error(String message, Throwable throwable) {
+        }
+
+        @Override
+        public void trace(String message, Throwable throwable) {
+        }
+
+        @Override
+        public void trace(Throwable throwable) {
+        }
+    };
+
+    private Response buildResponse(int status, String reason) {
+        Request request = Request.create(Request.HttpMethod.GET, "http://localhost", Collections.emptyMap(), null,
+                new RequestTemplate());
+        return Response.builder()
+                .status(status)
+                .reason(reason)
+                .request(request)
+                .headers(Collections.emptyMap())
+                .build();
+    }
+
+    @Test
+    void returnsUnauthorizedExceptionFor401() {
+        MavenCentral.MavenCentralErrorDecoder decoder = new MavenCentral.MavenCentralErrorDecoder(logger);
+        Response response = buildResponse(401, "Unauthorized");
+        Exception ex = decoder.decode("method", response);
+        assertThat(ex).isInstanceOf(MavenCentralAPIException.class);
+        assertThat(((MavenCentralAPIException) ex).getStatus()).isEqualTo(401);
+        assertThat(ex.getMessage()).contains("Unauthorized");
+    }
+
+    @Test
+    void returnsForbiddenExceptionFor403() {
+        MavenCentral.MavenCentralErrorDecoder decoder = new MavenCentral.MavenCentralErrorDecoder(logger);
+        Response response = buildResponse(403, "Forbidden");
+        Exception ex = decoder.decode("method", response);
+        assertThat(ex).isInstanceOf(MavenCentralAPIException.class);
+        assertThat(((MavenCentralAPIException) ex).getStatus()).isEqualTo(403);
+        assertThat(ex.getMessage()).contains("Forbidden");
+    }
+
+    @Test
+    void returnsRetryableExceptionFor500() {
+        MavenCentral.MavenCentralErrorDecoder decoder = new MavenCentral.MavenCentralErrorDecoder(logger);
+        Response response = buildResponse(500, "Internal Server Error");
+        Exception ex = decoder.decode("method", response);
+        assertThat(ex).isInstanceOf(RetryableException.class);
+    }
+
+    @Test
+    void returnsDefaultExceptionForOtherStatus() {
+        MavenCentral.MavenCentralErrorDecoder decoder = new MavenCentral.MavenCentralErrorDecoder(logger);
+        Response response = buildResponse(404, "Not Found");
+        Exception ex = decoder.decode("method", response);
+        assertThat(ex).isInstanceOf(MavenCentralAPIException.class);
+        assertThat(((MavenCentralAPIException) ex).getStatus()).isEqualTo(404);
+        assertThat(ex.getMessage()).contains("Not Found");
+    }
+}


### PR DESCRIPTION
Improve error messages for 401/403 in MavenCentral deploy (Fixes #1922)

<!-- The issue this PR addresses -->
Fixes #1922

### Context
This PR improves developer experience by replacing the vague "Unexpected error" during MavenCentral deployments with clear, actionable error messages.

- For 401 Unauthorized responses:
  ❌ Unauthorized (401): Please check your Maven Central credentials or token.

- For 403 Forbidden responses:
  ❌ Forbidden (403): You don't have permission to upload to this repository.

This makes it much easier to diagnose publishing issues and removes the need to dig into logs.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Code is original and Apache 2.0-compatible.
- [x] Unit tests added (`MavenCentralErrorDecoderTest`).
- [ ] Documentation not required for this internal change.