### PR TITLE
fix(packagers): ensure org.opencontainers.image.source is set in Docker labels

### DIFF
--- a/api/jreleaser-model-api/src/main/java/org/jreleaser/model/Constants.java
+++ b/api/jreleaser-model-api/src/main/java/org/jreleaser/model/Constants.java
@@ -517,4 +517,5 @@ public interface Constants {
     String LABEL_OCI_IMAGE_VERSION = "org.opencontainers.image.version";
     String LABEL_OCI_IMAGE_LICENSES = "org.opencontainers.image.licenses";
     String LABEL_OCI_IMAGE_URL = "org.opencontainers.image.url";
+    String LABEL_OCI_IMAGE_SOURCE = "org.opencontainers.image.source";
 }

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/packagers/DockerPackagerValidator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/packagers/DockerPackagerValidator.java
@@ -50,6 +50,7 @@ import static org.jreleaser.model.Constants.LABEL_OCI_IMAGE_REVISION;
 import static org.jreleaser.model.Constants.LABEL_OCI_IMAGE_TITLE;
 import static org.jreleaser.model.Constants.LABEL_OCI_IMAGE_URL;
 import static org.jreleaser.model.Constants.LABEL_OCI_IMAGE_VERSION;
+import static org.jreleaser.model.Constants.LABEL_OCI_IMAGE_SOURCE;
 import static org.jreleaser.model.internal.packagers.DockerConfiguration.Registry.DEFAULT_NAME;
 import static org.jreleaser.model.internal.validation.common.ExtraPropertiesValidator.mergeExtraProperties;
 import static org.jreleaser.model.internal.validation.common.TemplateValidator.validateTemplate;
@@ -389,6 +390,10 @@ public final class DockerPackagerValidator {
         if (!self.getLabels().containsKey(LABEL_OCI_IMAGE_REVISION)) {
             self.getLabels().put(LABEL_OCI_IMAGE_REVISION, "{{commitFullHash}}");
         }
+        if (!self.getLabels().containsKey(LABEL_OCI_IMAGE_SOURCE)) {
+            self.getLabels().put(LABEL_OCI_IMAGE_SOURCE, "{{projectSource}}");
+        }
+        
     }
 
     private static void validateRegistries(JReleaserContext context, DockerConfiguration self, DockerConfiguration other, Errors errors, String element) {

--- a/core/jreleaser-model-impl/src/test/java/org/jreleaser/model/internal/validation/packagers/DockerPackagerValidatorTest.java
+++ b/core/jreleaser-model-impl/src/test/java/org/jreleaser/model/internal/validation/packagers/DockerPackagerValidatorTest.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2025 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.model.internal.validation.packagers;
+
+import org.jreleaser.model.internal.packagers.DockerPackager;
+import org.junit.jupiter.api.Test;
+
+import static org.jreleaser.model.Constants.LABEL_OCI_IMAGE_SOURCE;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DockerPackagerValidatorTest {
+    @Test
+    void shouldSetSourceLabelIfMissing() throws Exception {
+        DockerPackager config = new DockerPackager();
+        // Do not set LABEL_OCI_IMAGE_SOURCE
+        assertFalse(config.getLabels().containsKey(LABEL_OCI_IMAGE_SOURCE));
+
+        // Use reflection to call the private validateLabels method
+        java.lang.reflect.Method method = DockerPackagerValidator.class.getDeclaredMethod("validateLabels", org.jreleaser.model.internal.packagers.DockerConfiguration.class);
+        method.setAccessible(true);
+        method.invoke(null, config);
+
+        assertTrue(config.getLabels().containsKey(LABEL_OCI_IMAGE_SOURCE));
+        assertEquals("{{projectSource}}", config.getLabels().get(LABEL_OCI_IMAGE_SOURCE));
+    }
+}


### PR DESCRIPTION
Fixes #1933

Adds validation to ensure the OCI label `org.opencontainers.image.source` is set when missing.
Sets it to `{{projectSource}}` by default if not already present.

- Validation added in DockerPackagerValidator
- Imports label constant from org.jreleaser.model.Constants
- Tests included and passing