### PR TITLE
feat: warn on missing variables

### DIFF
--- a/api/jreleaser-resource-bundle/src/main/resources/org/jreleaser/bundle/Messages.properties
+++ b/api/jreleaser-resource-bundle/src/main/resources/org/jreleaser/bundle/Messages.properties
@@ -585,6 +585,7 @@ ERROR_files_create                = Unable to create: {}
 ERROR_files_cycle                 = Cycle detected: {}
 ERROR_files_copy_attributes       = Unable to copy all attributes to: {}
 ERROR_mustache_write_value        = Failed to write value:
+ERROR_mustache_missing_variable   = Missing variable: {}
 ERROR_unexpected_file_read        = Unexpected error when reading file {}
 ERROR_invalid_file_input          = Invalid file definition {}
 ERROR_invalid_json_input          = Could not convert input into JSON


### PR DESCRIPTION
<!-- The issue this PR addresses -->
<!-- Please reference the issue this PR solves -->
Fixes #1960  

### Context

prints out warning for missing variables found when evaluating mustache templates.

It is a draft as I quicky realized that to actually log this I would need to have JReleaseLogger available and that would require lots of call point changes so did not want to do that.

so mainly this is just there to show where jreleaser could hook in to help users - whats difficult is that that jreleaser evaluates strings with no context so file etc. info is not very meaningful.

ultimately would be nice to even have ability to fail/error the build if this happens.