### PR TITLE
fix: Normalize URL for Nexus3 deployer

### DIFF
--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/deploy/maven/Nexus3MavenDeployer.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/deploy/maven/Nexus3MavenDeployer.java
@@ -179,11 +179,17 @@ public final class Nexus3MavenDeployer extends AbstractMavenDeployer<Nexus3Maven
 
     }
 
+    /**
+     * The {@link org.jreleaser.model.internal.validation.deploy.maven.MavenDeployersValidator}
+     * removes the trailing slash (if any) from any Maven URL property.
+     * We have to re-introduce it for Nexus3 or else the "deploy" operation will fail.
+     * That's why we normalize the URL here.
+     */
     @Override
     public String getResolvedUrl(TemplateContext props) {
         props.set("username", getUsername());
         props.set("owner", getUsername());
         props.setAll(getExtraProperties());
-        return resolveTemplate(getUrl(), props);
+        return normalizeUrl(resolveTemplate(getUrl(), props));
     }
 }


### PR DESCRIPTION
Fixes gh-1967

### Context
Add normalization for the Nexus3 URL to ensure the repository trailing slash is included when performing the deploy operation.

### Checklist
- [X] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [X] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
