### PR TITLE
fix: Ensure Nexus3 URLs don't have a trailing slash

### DIFF
--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/deploy/maven/Nexus3MavenDeployer.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/deploy/maven/Nexus3MavenDeployer.java
@@ -182,14 +182,14 @@ public final class Nexus3MavenDeployer extends AbstractMavenDeployer<Nexus3Maven
     /**
      * The {@link org.jreleaser.model.internal.validation.deploy.maven.MavenDeployersValidator}
      * removes the trailing slash (if any) from any Maven URL property.
-     * We have to re-introduce it for Nexus3 or else the "deploy" operation will fail.
-     * That's why we normalize the URL here.
+     * Unlike Nexus2 which requires a trailing slash, Nexus3 doesn't work if it's present.
+     * That's why we don't normalize the URL here.
      */
     @Override
     public String getResolvedUrl(TemplateContext props) {
         props.set("username", getUsername());
         props.set("owner", getUsername());
         props.setAll(getExtraProperties());
-        return normalizeUrl(resolveTemplate(getUrl(), props));
+        return resolveTemplate(getUrl(), props);
     }
 }


### PR DESCRIPTION
### Context

This reverts the change done in https://github.com/jreleaser/jreleaser/pull/1968, which was not correct for Nexus3.

@aalmiray this is awkward. I've been testing both snapshot and production releases across nexus2 and nexus3. It turned out, somehow, I mixed things up, leading to the issue I raised yesterday (https://github.com/jreleaser/jreleaser/issues/1967) which was actually due to misconfiguration. I tested both workflows across both platforms again, and the current version of JReleaser 1.19.0 works correctly.

Nexus3 fails if there's any trailing slash, so it's actually correct that the URL is not normalized. I updated the JavaDoc to explain why it's different from Nexus2.

I'm so sorry about the confusion.

### Checklist
- [X] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [X] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.