### PR TITLE
fix: disable up-to-date checks in JReleaserConfigTask

### DIFF
--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserConfigTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserConfigTask.groovy
@@ -74,6 +74,9 @@ abstract class JReleaserConfigTask extends AbstractPlatformAwareJReleaserTask {
         deploy = objects.property(Boolean).convention(false)
         download = objects.property(Boolean).convention(false)
         command = JReleaserCommand.CONFIG
+
+        // Disable up-to-date checks: jreleaser/issues/1972
+        this.outputs.upToDateWhen { false }
     }
 
     @Option(option = 'full', description = 'Display full configuration (OPTIONAL).')


### PR DESCRIPTION
<!-- The issue this PR addresses -->
<!-- Please reference the issue this PR solves -->
Fixes #1972

### Context
<!-- What problem does this change address? -->
<!-- Link to relevant issues or discussions here -->
This change disables up-to-date checks in the `jreleaserConfig` task, solving the issue of subsequent invocations of the task producing no output.

### Checklist
- [ x ] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [ x ] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ x ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.