### PR TITLE
feat(release): add support for github immutable releases

### DIFF
--- a/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/release/GithubReleaser.java
+++ b/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/release/GithubReleaser.java
@@ -33,6 +33,8 @@ public interface GithubReleaser extends Releaser {
 
     boolean isDraft();
 
+    boolean isImmutableRelease();
+
     String getDiscussionCategoryName();
 
     ReleaseNotes getReleaseNotes();

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/release/GithubReleaser.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/release/GithubReleaser.java
@@ -38,6 +38,7 @@ public final class GithubReleaser extends BaseReleaser<org.jreleaser.model.api.r
     private final ReleaseNotes releaseNotes = new ReleaseNotes();
 
     private Boolean draft;
+    private Boolean immutableRelease;
     private String discussionCategoryName;
     private org.jreleaser.model.api.release.GithubReleaser.MakeLatest makeLatest;
 
@@ -53,6 +54,11 @@ public final class GithubReleaser extends BaseReleaser<org.jreleaser.model.api.r
         @Override
         public boolean isDraft() {
             return GithubReleaser.this.isDraft();
+        }
+
+        @Override
+        public boolean isImmutableRelease() {
+            return GithubReleaser.this.isImmutableRelease();
         }
 
         @Override
@@ -345,6 +351,18 @@ public final class GithubReleaser extends BaseReleaser<org.jreleaser.model.api.r
         return null != draft;
     }
 
+    public boolean isImmutableRelease() {
+        return null != immutableRelease && immutableRelease;
+    }
+
+    public void setImmutableRelease(Boolean immutableRelease) {
+        this.immutableRelease = immutableRelease;
+    }
+
+    public boolean isImmutableReleaseSet() {
+        return null != immutableRelease;
+    }
+
     public String getDiscussionCategoryName() {
         return discussionCategoryName;
     }
@@ -370,6 +388,7 @@ public final class GithubReleaser extends BaseReleaser<org.jreleaser.model.api.r
     public Map<String, Object> asMap(boolean full) {
         Map<String, Object> map = super.asMap(full);
         map.put("draft", isDraft());
+        map.put("immutableRelease", isImmutableRelease());
         map.put("discussionCategoryName", discussionCategoryName);
         map.put("releaseNotes", releaseNotes.asMap(full));
         map.put("makeLatest", null != makeLatest ? makeLatest.formatted() : null);

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/dsl/release/GithubReleaser.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/dsl/release/GithubReleaser.groovy
@@ -30,6 +30,8 @@ import org.gradle.api.provider.Property
 interface GithubReleaser extends BaseReleaser {
     Property<Boolean> getDraft()
 
+    Property<Boolean> getImmutableRelease()
+
     Property<org.jreleaser.model.api.release.GithubReleaser.MakeLatest> getMakeLatest()
 
     Property<String> getDiscussionCategoryName()

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/release/GithubReleaserImpl.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/release/GithubReleaserImpl.groovy
@@ -39,6 +39,7 @@ import static org.jreleaser.util.StringUtils.isNotBlank
 @CompileStatic
 class GithubReleaserImpl extends BaseReleaserImpl implements GithubReleaser {
     final Property<Boolean> draft
+    final Property<Boolean> immutableRelease
     final Property<org.jreleaser.model.api.release.GithubReleaser.MakeLatest> makeLatest
     final Property<String> discussionCategoryName
     final ChangelogImpl changelog
@@ -96,6 +97,7 @@ class GithubReleaserImpl extends BaseReleaserImpl implements GithubReleaser {
         org.jreleaser.model.internal.release.GithubReleaser service = new org.jreleaser.model.internal.release.GithubReleaser()
         toModel(service)
         if (draft.present) service.draft = draft.get()
+        if (immutableRelease.present) service.immutableRelease = immutableRelease.get()
         if (makeLatest.present) service.makeLatest = makeLatest.get()
         service.prerelease = prerelease.toModel()
         service.releaseNotes = releaseNotes.toModel()

--- a/sdks/jreleaser-github-java-sdk/src/main/java/org/jreleaser/sdk/github/api/GhRelease.java
+++ b/sdks/jreleaser-github-java-sdk/src/main/java/org/jreleaser/sdk/github/api/GhRelease.java
@@ -36,6 +36,7 @@ public class GhRelease {
     private String body;
     private boolean prerelease;
     private boolean draft;
+    private boolean immutableRelease;
     private String targetCommitish;
     private Date createdAt;
     private Date publishedAt;
@@ -112,6 +113,14 @@ public class GhRelease {
 
     public void setDraft(boolean draft) {
         this.draft = draft;
+    }
+
+    public boolean isImmutableRelease() {
+        return immutableRelease;
+    }
+
+    public void setImmutableRelease(boolean immutableRelease) {
+        this.immutableRelease = immutableRelease;
     }
 
     public String getTargetCommitish() {


### PR DESCRIPTION
<!-- The issue this PR addresses -->
<!-- Please reference the issue this PR solves -->
Fixes #1978 .

### Context
<!-- What problem does this change address? -->
<!-- Link to relevant issues or discussions here -->
GitHub recently added immutable releases, where the release cannot be changed afterwards. To support this, the release must be made as a draft, then assets uploaded, and finally published after which the assets cannot be modified.

I added the option `immutableRelease: true` which changes the handles this.

```yml
release:
  github:
    [...]
    immutableRelease: true
```

It might be sensible to make this the default workflow and not add another parameter. I cannot really think about a usecase where the release being in draft mode while the assets are uploaded would break anything, but would love further input on this.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
