### PR TITLE
docs: public keyserver link from http to https

### DIFF
--- a/src/jreleaser/templates/wiki-release-page.md.tpl
+++ b/src/jreleaser/templates/wiki-release-page.md.tpl
@@ -85,7 +85,7 @@ PASSED: Verified SLSA provenance
 
 ### PGP
 
-1. Download the [public key](http://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf1d5f6a91c86b0702cd0734bccc55c5167419adb)
+1. Download the [public key](https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf1d5f6a91c86b0702cd0734bccc55c5167419adb)
 2. Verify the fingerprint matches the following:
 ```sh
 $ gpg --show-keys aalmiray.asc


### PR DESCRIPTION
### Context
The public key download link http://keyserver.ubuntu.com/xxx was not returning any content while the https link does

