### PR TITLE
feat(jlink): Resolve multi-release template in JlinkAssemblerProcessor

### DIFF
--- a/core/jreleaser-engine/src/main/java/org/jreleaser/assemblers/JlinkAssemblerProcessor.java
+++ b/core/jreleaser-engine/src/main/java/org/jreleaser/assemblers/JlinkAssemblerProcessor.java
@@ -389,6 +389,7 @@ public class JlinkAssemblerProcessor extends AbstractAssemblerProcessor<org.jrel
         Command cmd = new Command(jdepsExecutable.toAbsolutePath().toString());
         String multiRelease = assembler.getJdeps().getMultiRelease();
         if (isNotBlank(multiRelease)) {
+            multiRelease = resolveTemplate(context.getLogger(), multiRelease, props);
             cmd.arg("--multi-release")
                 .arg(multiRelease);
         }


### PR DESCRIPTION
<!-- The issue this PR addresses -->
<!-- Please reference the issue this PR solves -->
Fixes ##2030

### Context
<!-- What problem does this change address? -->
<!-- Link to relevant issues or discussions here -->
I modified `JlinkAssemblerProcessor` to apply template resolution to the `multiRelease` value before passing it to the jdeps command. This change ensures that template variables are properly resolved, just like other similar fields in the same method (e.g., `targets`).
```yaml
assemble:
  jlink:
    app-jre:
      jdeps:
        multiRelease: '{{projectJavaVersionMajor}}'
```

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
