### PR TITLE
fix: add explicit plexus-utils dependency for Maven 3.9 compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -100,6 +100,7 @@ picocliVersion         = 4.7.7
 plexusVersion          = 4.0.2
 plexusAnnotationsVersion = 2.2.0
 plexusArchiverVersion  = 4.10.4
+plexusUtilsVersion     = 3.5.1
 pomcheckerVersion      = 1.14.0
 tikaVersion            = 2.9.2
 wiremockVersion        = 2.35.0

--- a/plugins/jdks-maven-plugin/jdks-maven-plugin.gradle
+++ b/plugins/jdks-maven-plugin/jdks-maven-plugin.gradle
@@ -43,7 +43,7 @@ dependencies {
     api project(':jreleaser-disco-java-sdk')
     api "org.twdata.maven:mojo-executor:$mojoExecutorVersion"
     api "org.codehaus.plexus:plexus-archiver:$plexusArchiverVersion"
-    api "org.codehaus.plexus:plexus-utils:3.5.1"
+    api "org.codehaus.plexus:plexus-utils:$plexusUtilsVersion"
 
     compileOnly "org.apache.maven:maven-core:$mavenVersion"
     compileOnly "org.apache.maven:maven-plugin-api:$mavenVersion"


### PR DESCRIPTION
### Description
This PR fixes the `ClassNotFoundException` occurring in Maven 3.9+ by explicitly adding the `plexus-utils` dependency to `jdks-maven-plugin.gradle`.

Starting with Maven 3.9.0, `plexus-utils` is no longer automatically injected. Adding it explicitly as suggested by the maintainer resolves the issue.

### Verification
- Confirmed with `./gradlew :plugins:jdks-maven-plugin:build` (Success)
- Environment: Windows 11, Java 17

Fixes #2045 
