### PR TITLE
fix(deploy): skipPublicationCheck not stopping at PUBLISHING state

### DIFF
--- a/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/MavenCentral.java
+++ b/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/MavenCentral.java
@@ -183,8 +183,10 @@ public class MavenCentral {
     private void waitForState(String deploymentId, boolean checkTimeout, State... states) throws MavenCentralException {
         context.getLogger().debug(RB.$("maven.central.wait.deployment.state", deploymentId, Arrays.asList(states)));
 
+        Set<State> acceptableStates = new LinkedHashSet<>(Arrays.asList(states));
         Boolean[] timeout = new Boolean[]{false};
-        Optional<Deployment> deployment = retrier.retry(o -> o.map(Deployment::isTransitioning).orElse(false),
+        Optional<Deployment> deployment = retrier.retry(
+            o -> o.map(d -> d.isTransitioning(acceptableStates)).orElse(false),
             () -> status(deploymentId),
             states[0] != State.PUBLISHED? () -> {}: () -> {
                 context.getLogger().warn(RB.$("WARN_maven_central_publication_timeout", deploymentId));

--- a/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/api/Deployment.java
+++ b/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/api/Deployment.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Andres Almiray
@@ -99,5 +100,20 @@ public class Deployment {
         return deploymentState == State.PENDING ||
             deploymentState == State.VALIDATING ||
             deploymentState == State.PUBLISHING;
+    }
+
+    /**
+     * Checks if deployment is still transitioning, considering acceptable terminal states.
+     * If the current state is in the acceptable states set, it's not considered transitioning.
+     *
+     * @param acceptableStates states that should be considered as terminal (not transitioning)
+     * @return true if still transitioning, false if reached an acceptable state
+     * @since 1.23.0
+     */
+    public boolean isTransitioning(Set<State> acceptableStates) {
+        if (acceptableStates.contains(deploymentState)) {
+            return false;
+        }
+        return isTransitioning();
     }
 }

--- a/sdks/jreleaser-mavencentral-java-sdk/src/test/java/org/jreleaser/sdk/mavencentral/api/DeploymentTest.java
+++ b/sdks/jreleaser-mavencentral-java-sdk/src/test/java/org/jreleaser/sdk/mavencentral/api/DeploymentTest.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2026 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.sdk.mavencentral.api;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Stepan Romankov
+ * @since 1.23.0
+ */
+class DeploymentTest {
+
+    @Test
+    void isTransitioning_withPendingState_returnsTrue() {
+        Deployment deployment = new Deployment();
+        deployment.setDeploymentState(State.PENDING);
+        assertTrue(deployment.isTransitioning());
+    }
+
+    @Test
+    void isTransitioning_withValidatingState_returnsTrue() {
+        Deployment deployment = new Deployment();
+        deployment.setDeploymentState(State.VALIDATING);
+        assertTrue(deployment.isTransitioning());
+    }
+
+    @Test
+    void isTransitioning_withPublishingState_returnsTrue() {
+        Deployment deployment = new Deployment();
+        deployment.setDeploymentState(State.PUBLISHING);
+        assertTrue(deployment.isTransitioning());
+    }
+
+    @Test
+    void isTransitioning_withPublishedState_returnsFalse() {
+        Deployment deployment = new Deployment();
+        deployment.setDeploymentState(State.PUBLISHED);
+        assertFalse(deployment.isTransitioning());
+    }
+
+    @Test
+    void isTransitioning_withFailedState_returnsFalse() {
+        Deployment deployment = new Deployment();
+        deployment.setDeploymentState(State.FAILED);
+        assertFalse(deployment.isTransitioning());
+    }
+
+    @Test
+    void isTransitioningWithAcceptableStates_whenPublishingIsAcceptable_returnsFalse() {
+        Deployment deployment = new Deployment();
+        deployment.setDeploymentState(State.PUBLISHING);
+
+        // When skipPublicationCheck is true, PUBLISHING should be acceptable
+        Set<State> acceptableStates = Set.of(State.PUBLISHING, State.PUBLISHED, State.FAILED);
+
+        assertFalse(deployment.isTransitioning(acceptableStates));
+    }
+
+    @Test
+    void isTransitioningWithAcceptableStates_whenPublishingIsNotAcceptable_returnsTrue() {
+        Deployment deployment = new Deployment();
+        deployment.setDeploymentState(State.PUBLISHING);
+
+        // When skipPublicationCheck is false, only PUBLISHED and FAILED are acceptable
+        Set<State> acceptableStates = Set.of(State.PUBLISHED, State.FAILED);
+
+        assertTrue(deployment.isTransitioning(acceptableStates));
+    }
+
+    @Test
+    void isTransitioningWithAcceptableStates_withValidatedState_returnsFalse() {
+        Deployment deployment = new Deployment();
+        deployment.setDeploymentState(State.VALIDATED);
+
+        // During upload, VALIDATED is an acceptable terminal state
+        Set<State> acceptableStates = Set.of(State.VALIDATED, State.FAILED);
+
+        assertFalse(deployment.isTransitioning(acceptableStates));
+    }
+
+    @Test
+    void isTransitioningWithAcceptableStates_withPendingState_returnsTrue() {
+        Deployment deployment = new Deployment();
+        deployment.setDeploymentState(State.PENDING);
+
+        Set<State> acceptableStates = Set.of(State.PUBLISHING, State.PUBLISHED, State.FAILED);
+
+        assertTrue(deployment.isTransitioning(acceptableStates));
+    }
+}


### PR DESCRIPTION
## Summary
Fixes a bug where `skipPublicationCheck = true` does not actually skip waiting for `PUBLISHED` state.

## Problem
When `skipPublicationCheck` is set to `true`, the `waitForState` method correctly includes `PUBLISHING` as an acceptable terminal state:

```java
if (skipPublicationCheck) {
    waitForState(deploymentId, true, State.PUBLISHING, State.PUBLISHED, State.FAILED);
}
```

However, the retry loop uses `Deployment.isTransitioning()` which considers `PUBLISHING` as a transitioning state:

```java
public boolean isTransitioning() {
    return deploymentState == State.PENDING ||
        deploymentState == State.VALIDATING ||
        deploymentState == State.PUBLISHING;  // <-- PUBLISHING is considered transitioning
}
```

This causes the retry loop to continue polling even when `PUBLISHING` state is reached, defeating the purpose of `skipPublicationCheck`.

## Solution
Add an overloaded `isTransitioning(Set<State>)` method that considers acceptable states as terminal:

```java
public boolean isTransitioning(Set<State> acceptableStates) {
    if (acceptableStates.contains(deploymentState)) {
        return false;
    }
    return isTransitioning();
}
```

The `waitForState` method now passes the acceptable states to this new method, allowing the retry loop to stop when `PUBLISHING` is reached if `skipPublicationCheck` is enabled.

## Testing
Added unit tests for the new `isTransitioning(Set<State>)` method covering:
- PUBLISHING state with skipPublicationCheck enabled (should not be transitioning)
- PUBLISHING state with skipPublicationCheck disabled (should be transitioning)
- Other state combinations

## Related
This is a follow-up fix to #2011 which added the `skipPublicationCheck` configuration option.