### PR TITLE
feat: add riscv_64 platform support

### DIFF
--- a/api/jreleaser-utils/src/main/java/org/jreleaser/dependencies/os/Detector.java
+++ b/api/jreleaser-utils/src/main/java/org/jreleaser/dependencies/os/Detector.java
@@ -252,7 +252,7 @@ public abstract class Detector {
             return "riscv";
         }
         if ("riscv64".equals(value)) {
-            return "riscv64";
+            return "riscv_64";
         }
         if ("e2k".equals(value)) {
             return "e2k";

--- a/api/jreleaser-utils/src/main/java/org/jreleaser/util/PlatformUtils.java
+++ b/api/jreleaser-utils/src/main/java/org/jreleaser/util/PlatformUtils.java
@@ -81,7 +81,8 @@ public final class PlatformUtils {
             "ppcle_64",
             "s390_32",
             "s390_64",
-            "riscv"));
+            "riscv",
+            "riscv_64"));
         OS_ARCHS.sort(Comparator.naturalOrder());
     }
 


### PR DESCRIPTION
## Summary

- Normalize `riscv64` arch detection to `riscv_64` in `Detector.java` (consistent with `aarch_64`, `mips_64`, `loongarch_64`, etc.)
- Add `riscv_64` to `OS_ARCHS` in `PlatformUtils.java` so `linux-riscv_64` is recognized as a valid platform

## Problem

When setting `JRELEASER_PLATFORM_OVERRIDE=linux-riscv_64` for cross-compiled RISC-V 64-bit binaries, JReleaser rejects the platform:

```
[WARN]  Unsupported platform 'linux-riscv_64', using 'linux-x86_64' instead
```

This is because:
1. `Detector.normalizeArch()` returns `"riscv64"` (no underscore) instead of `"riscv_64"`, breaking the naming convention
2. Neither `riscv64` nor `riscv_64` is in the `OS_ARCHS` list, so `isSupported()` rejects it

## Changes

| File | Change |
|------|--------|
| `Detector.java:254-255` | `riscv64` → `riscv_64` (naming convention) |
| `PlatformUtils.java:85` | Add `riscv_64` to `OS_ARCHS` |

## Context

This came up while adding RISC-V 64-bit support to [sdkman-cli-native](https://github.com/sdkman/sdkman-cli-native). Similar to the `x86_32` addition in #1824.

Fixes #2061