### PR TITLE
feat(announce): Add Twist announcer support

### DIFF
--- a/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/announce/Announce.java
+++ b/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/announce/Announce.java
@@ -65,6 +65,8 @@ public interface Announce extends Domain, Activatable {
 
     TelegramAnnouncer getTelegram();
 
+    TwistAnnouncer getTwist();
+
     TwitterAnnouncer getTwitter();
 
     Map<String, ? extends HttpAnnouncer> getHttp();

--- a/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/announce/TwistAnnouncer.java
+++ b/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/announce/TwistAnnouncer.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2026 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.model.api.announce;
+
+/**
+ * @author Usman Shaikh
+ * @since 1.23.0
+ */
+public interface TwistAnnouncer extends Announcer {
+    String TYPE = "twist";
+    String TWIST_WEBHOOK = "TWIST_WEBHOOK";
+
+    String getWebhook();
+
+    String getMessageTemplate();
+}

--- a/core/jreleaser-engine/jreleaser-engine.gradle
+++ b/core/jreleaser-engine/jreleaser-engine.gradle
@@ -50,6 +50,7 @@ dependencies {
     api project(':jreleaser-slack-java-sdk')
     api project(':jreleaser-teams-java-sdk')
     api project(':jreleaser-telegram-java-sdk')
+    api project(':jreleaser-twist-java-sdk')
     api project(':jreleaser-twitter-java-sdk')
     api project(':jreleaser-webhooks-java-sdk')
     api project(':jreleaser-zulip-java-sdk')

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/JReleaserSupport.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/JReleaserSupport.java
@@ -63,6 +63,7 @@ public final class JReleaserSupport {
         set.add(org.jreleaser.model.api.announce.SlackAnnouncer.TYPE);
         set.add(org.jreleaser.model.api.announce.TeamsAnnouncer.TYPE);
         set.add(org.jreleaser.model.api.announce.TelegramAnnouncer.TYPE);
+        set.add(org.jreleaser.model.api.announce.TwistAnnouncer.TYPE);
         set.add(org.jreleaser.model.api.announce.TwitterAnnouncer.TYPE);
         set.add(org.jreleaser.model.api.announce.WebhooksAnnouncer.TYPE);
         set.add(org.jreleaser.model.api.announce.ZulipAnnouncer.TYPE);

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/announce/Announce.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/announce/Announce.java
@@ -38,7 +38,7 @@ import static org.jreleaser.util.StringUtils.isBlank;
  * @since 0.1.0
  */
 public final class Announce extends AbstractActivatable<Announce> implements Domain {
-    private static final long serialVersionUID = -2945770875328891983L;
+    private static final long serialVersionUID = 3822217256168802121L;
 
     private final ArticleAnnouncer article = new ArticleAnnouncer();
     private final BlueskyAnnouncer bluesky = new BlueskyAnnouncer();
@@ -57,6 +57,7 @@ public final class Announce extends AbstractActivatable<Announce> implements Dom
     private final SlackAnnouncer slack = new SlackAnnouncer();
     private final TeamsAnnouncer teams = new TeamsAnnouncer();
     private final TelegramAnnouncer telegram = new TelegramAnnouncer();
+    private final TwistAnnouncer twist = new TwistAnnouncer();
     private final TwitterAnnouncer twitter = new TwitterAnnouncer();
     private final ZulipAnnouncer zulip = new ZulipAnnouncer();
     @JsonIgnore
@@ -159,6 +160,11 @@ public final class Announce extends AbstractActivatable<Announce> implements Dom
         }
 
         @Override
+        public org.jreleaser.model.api.announce.TwistAnnouncer getTwist() {
+            return twist.asImmutable();
+        }
+
+        @Override
         public org.jreleaser.model.api.announce.TwitterAnnouncer getTwitter() {
             return twitter.asImmutable();
         }
@@ -222,6 +228,7 @@ public final class Announce extends AbstractActivatable<Announce> implements Dom
         setSlack(source.slack);
         setTeams(source.teams);
         setTelegram(source.telegram);
+        setTwist(source.twist);
         setTwitter(source.twitter);
         setZulip(source.zulip);
         setConfiguredHttp(source.httpAnnouncers);
@@ -410,6 +417,14 @@ public final class Announce extends AbstractActivatable<Announce> implements Dom
         this.telegram.merge(telegram);
     }
 
+    public TwistAnnouncer getTwist() {
+        return twist;
+    }
+
+    public void setTwist(TwistAnnouncer twist) {
+        this.twist.merge(twist);
+    }
+
     @Deprecated
     @JsonPropertyDescription("announce.twitter is deprecated since 1.17.0 and will be removed in 2.0.0")
     public TwitterAnnouncer getTwitter() {
@@ -495,6 +510,7 @@ public final class Announce extends AbstractActivatable<Announce> implements Dom
         map.putAll(slack.asMap(full));
         map.putAll(teams.asMap(full));
         map.putAll(telegram.asMap(full));
+        map.putAll(twist.asMap(full));
         map.putAll(twitter.asMap(full));
         map.putAll(webhooksAnnouncer.asMap(full));
         map.putAll(zulip.asMap(full));
@@ -550,6 +566,8 @@ public final class Announce extends AbstractActivatable<Announce> implements Dom
                 return (A) getTelegram();
             case org.jreleaser.model.api.announce.TwitterAnnouncer.TYPE:
                 return (A) getTwitter();
+            case org.jreleaser.model.api.announce.TwistAnnouncer.TYPE:
+                return (A) getTwist();
             case org.jreleaser.model.api.announce.WebhooksAnnouncer.TYPE:
                 return (A) getConfiguredWebhooks();
             case org.jreleaser.model.api.announce.ZulipAnnouncer.TYPE:

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/announce/TwistAnnouncer.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/announce/TwistAnnouncer.java
@@ -1,0 +1,190 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2026 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.model.internal.announce;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.jreleaser.bundle.RB;
+import org.jreleaser.model.Active;
+import org.jreleaser.model.Constants;
+import org.jreleaser.model.JReleaserException;
+import org.jreleaser.model.internal.JReleaserContext;
+import org.jreleaser.mustache.TemplateContext;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static java.util.Collections.unmodifiableMap;
+import static org.jreleaser.model.Constants.HIDE;
+import static org.jreleaser.model.Constants.KEY_TAG_NAME;
+import static org.jreleaser.model.Constants.UNSET;
+import static org.jreleaser.model.api.announce.TwistAnnouncer.TYPE;
+import static org.jreleaser.mustache.MustacheUtils.applyTemplate;
+import static org.jreleaser.mustache.MustacheUtils.applyTemplates;
+import static org.jreleaser.util.StringUtils.isNotBlank;
+
+/**
+ * @author Usman Shaikh
+ * @since 1.23.0
+ */
+public final class TwistAnnouncer extends AbstractAnnouncer<TwistAnnouncer, org.jreleaser.model.api.announce.TwistAnnouncer> {
+    private static final long serialVersionUID = 2932524374605971375L;
+
+    private String webhook;
+    private String messageTemplate;
+
+    @JsonIgnore
+    private final org.jreleaser.model.api.announce.TwistAnnouncer immutable = new org.jreleaser.model.api.announce.TwistAnnouncer() {
+        private static final long serialVersionUID = 349478020816684741L;
+
+        @Override
+        public String getType() {
+            return org.jreleaser.model.api.announce.TwistAnnouncer.TYPE;
+        }
+
+        @Override
+        public String getWebhook() {
+            return webhook;
+        }
+
+        @Override
+        public String getMessageTemplate() {
+            return messageTemplate;
+        }
+
+        @Override
+        public String getName() {
+            return TwistAnnouncer.this.getName();
+        }
+
+        @Override
+        public boolean isSnapshotSupported() {
+            return TwistAnnouncer.this.isSnapshotSupported();
+        }
+
+        @Override
+        public Active getActive() {
+            return TwistAnnouncer.this.getActive();
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return TwistAnnouncer.this.isEnabled();
+        }
+
+        @Override
+        public Map<String, Object> asMap(boolean full) {
+            return unmodifiableMap(TwistAnnouncer.this.asMap(full));
+        }
+
+        @Override
+        public String getPrefix() {
+            return TwistAnnouncer.this.prefix();
+        }
+
+        @Override
+        public Map<String, Object> getExtraProperties() {
+            return unmodifiableMap(TwistAnnouncer.this.getExtraProperties());
+        }
+
+        @Override
+        public Integer getConnectTimeout() {
+            return TwistAnnouncer.this.getConnectTimeout();
+        }
+
+        @Override
+        public Integer getReadTimeout() {
+            return TwistAnnouncer.this.getReadTimeout();
+        }
+    };
+
+    public TwistAnnouncer() {
+        super(TYPE);
+    }
+
+    @Override
+    public org.jreleaser.model.api.announce.TwistAnnouncer asImmutable() {
+        return immutable;
+    }
+
+    @Override
+    public void merge(TwistAnnouncer source) {
+        super.merge(source);
+        this.webhook = merge(this.webhook, source.webhook);
+        this.messageTemplate = merge(this.messageTemplate, source.messageTemplate);
+    }
+
+    @Override
+    protected boolean isSet() {
+        return super.isSet() ||
+            isNotBlank(webhook) ||
+            isNotBlank(messageTemplate);
+    }
+
+    public String getResolvedMessageTemplate(JReleaserContext context, TemplateContext extraProps) {
+        TemplateContext props = context.fullProps();
+        applyTemplates(context.getLogger(), props, resolvedExtraProperties());
+        props.set(KEY_TAG_NAME, context.getModel().getRelease().getReleaser().getEffectiveTagName(context));
+        props.set(Constants.KEY_PREVIOUS_TAG_NAME, context.getModel().getRelease().getReleaser().getResolvedPreviousTagName(context));
+        props.setAll(extraProps);
+
+        Path templatePath = context.getBasedir().resolve(messageTemplate);
+        try {
+            Reader reader = java.nio.file.Files.newBufferedReader(templatePath);
+            return applyTemplate(context.getLogger(), reader, props);
+        } catch (IOException e) {
+            throw new JReleaserException(RB.$("ERROR_unexpected_error_reading_template",
+                context.relativizeToBasedir(templatePath)));
+        }
+    }
+
+    public String getWebhook() {
+        return webhook;
+    }
+
+    public void setWebhook(String webhook) {
+        this.webhook = webhook;
+    }
+
+    public String getMessageTemplate() {
+        return messageTemplate;
+    }
+
+    public void setMessageTemplate(String messageTemplate) {
+        this.messageTemplate = messageTemplate;
+    }
+
+    @Override
+    protected void asMap(boolean full, Map<String, Object> props) {
+        props.put("webhook", isNotBlank(webhook) ? HIDE : UNSET);
+        props.put("messageTemplate", messageTemplate);
+    }
+
+    public WebhookAnnouncer asWebhookAnnouncer() {
+        WebhookAnnouncer announcer = new WebhookAnnouncer();
+        announcer.setName(getName());
+        announcer.setWebhook(webhook);
+        announcer.setMessageTemplate(messageTemplate);
+        announcer.setStructuredMessage(false);
+        announcer.setConnectTimeout(getConnectTimeout());
+        announcer.setReadTimeout(getReadTimeout());
+        announcer.setExtraProperties(getExtraProperties());
+        return announcer;
+    }
+}

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/announce/AnnouncersValidator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/announce/AnnouncersValidator.java
@@ -41,6 +41,7 @@ import static org.jreleaser.model.internal.validation.announce.SlackAnnouncerVal
 import static org.jreleaser.model.internal.validation.announce.SmtpAnnouncerValidator.validateSmtp;
 import static org.jreleaser.model.internal.validation.announce.TeamsAnnouncerValidator.validateTeams;
 import static org.jreleaser.model.internal.validation.announce.TelegramAnnouncerValidator.validateTelegram;
+import static org.jreleaser.model.internal.validation.announce.TwistAnnouncerValidator.validateTwist;
 import static org.jreleaser.model.internal.validation.announce.TwitterAnnouncerValidator.validateTwitter;
 import static org.jreleaser.model.internal.validation.announce.WebhooksAnnouncerValidator.validateWebhooks;
 import static org.jreleaser.model.internal.validation.announce.ZulipAnnouncerValidator.validateZulip;
@@ -102,6 +103,8 @@ public final class AnnouncersValidator {
         mergeErrors(context, errors, incoming, announce.getTeams());
         validateTelegram(context, announce.getTelegram(), incoming);
         mergeErrors(context, errors, incoming, announce.getTelegram());
+        validateTwist(context, announce.getTwist(), incoming);
+        mergeErrors(context, errors, incoming, announce.getTwist());
         validateTwitter(context, announce.getTwitter(), incoming);
         mergeErrors(context, errors, incoming, announce.getTwitter());
         validateWebhooks(context, mode, announce.getConfiguredWebhooks(), incoming);
@@ -132,6 +135,7 @@ public final class AnnouncersValidator {
                 announce.getSlack().isEnabled() ||
                 announce.getTeams().isEnabled() ||
                 announce.getTelegram().isEnabled() ||
+                announce.getTwist().isEnabled() ||
                 announce.getTwitter().isEnabled() ||
                 announce.getConfiguredWebhooks().isEnabled() ||
                 announce.getZulip().isEnabled();

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/announce/TwistAnnouncerValidator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/announce/TwistAnnouncerValidator.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2026 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.model.internal.validation.announce;
+
+import org.jreleaser.bundle.RB;
+import org.jreleaser.model.internal.JReleaserContext;
+import org.jreleaser.model.internal.announce.TwistAnnouncer;
+import org.jreleaser.util.Errors;
+
+import java.nio.file.Files;
+
+import static org.jreleaser.model.api.announce.TwistAnnouncer.TWIST_WEBHOOK;
+import static org.jreleaser.model.internal.validation.common.Validator.checkProperty;
+import static org.jreleaser.model.internal.validation.common.Validator.resolveActivatable;
+import static org.jreleaser.model.internal.validation.common.Validator.validateTimeout;
+import static org.jreleaser.util.CollectionUtils.listOf;
+import static org.jreleaser.util.StringUtils.isBlank;
+import static org.jreleaser.util.StringUtils.isNotBlank;
+
+/**
+ * @author Usman Shaikh
+ * @since 1.23.0
+ */
+public final class TwistAnnouncerValidator {
+    private static final String DEFAULT_TWIST_TPL = "src/jreleaser/templates/twist.tpl";
+
+    private TwistAnnouncerValidator() {
+        // noop
+    }
+
+    public static void validateTwist(JReleaserContext context, TwistAnnouncer announcer, Errors errors) {
+        context.getLogger().debug("announce.twist");
+        resolveActivatable(context, announcer, "announce.twist", "NEVER");
+        if (!announcer.resolveEnabledWithSnapshot(context.getModel().getProject())) {
+            context.getLogger().debug(RB.$("validation.disabled"));
+            return;
+        }
+
+        announcer.setWebhook(
+            checkProperty(context,
+                listOf(
+                    "announce.twist.webhook",
+                    TWIST_WEBHOOK),
+                "announce.twist.webhook",
+                announcer.getWebhook(),
+                errors,
+                context.isDryrun()));
+
+        if (isBlank(announcer.getMessageTemplate())) {
+            announcer.setMessageTemplate(DEFAULT_TWIST_TPL);
+        }
+
+        if (isNotBlank(announcer.getMessageTemplate()) &&
+            !Files.exists(context.getBasedir().resolve(announcer.getMessageTemplate().trim()))) {
+            errors.configuration(RB.$("validation_directory_not_exist", "twist.messageTemplate", announcer.getMessageTemplate()));
+            announcer.disable();
+            return;
+        }
+
+        validateTimeout(announcer);
+    }
+}

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/dsl/announce/Announce.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/dsl/announce/Announce.groovy
@@ -66,6 +66,8 @@ interface Announce extends Activatable {
 
     TelegramAnnouncer getTelegram()
 
+    TwistAnnouncer getTwist()
+
     TwitterAnnouncer getTwitter()
 
     ZulipAnnouncer getZulip()
@@ -111,6 +113,8 @@ interface Announce extends Activatable {
     void teams(Action<? super TeamsAnnouncer> action)
 
     void telegram(Action<? super TelegramAnnouncer> action)
+
+    void twist(Action<? super TwistAnnouncer> action)
 
     void twitter(Action<? super TwitterAnnouncer> action)
 

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/dsl/announce/TwistAnnouncer.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/dsl/announce/TwistAnnouncer.groovy
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2026 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.gradle.plugin.dsl.announce
+
+import groovy.transform.CompileStatic
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+
+/**
+ *
+ * @author Usman Shaikh
+ * @since 1.23.0
+ */
+@CompileStatic
+interface TwistAnnouncer extends Announcer {
+    Property<String> getWebhook()
+
+    RegularFileProperty getMessageTemplate()
+
+    void setMessageTemplate(String messageTemplate)
+}

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/announce/AnnounceImpl.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/announce/AnnounceImpl.groovy
@@ -44,6 +44,7 @@ import org.jreleaser.gradle.plugin.dsl.announce.SlackAnnouncer
 import org.jreleaser.gradle.plugin.dsl.announce.SmtpAnnouncer
 import org.jreleaser.gradle.plugin.dsl.announce.TeamsAnnouncer
 import org.jreleaser.gradle.plugin.dsl.announce.TelegramAnnouncer
+import org.jreleaser.gradle.plugin.dsl.announce.TwistAnnouncer
 import org.jreleaser.gradle.plugin.dsl.announce.TwitterAnnouncer
 import org.jreleaser.gradle.plugin.dsl.announce.WebhookAnnouncer
 import org.jreleaser.gradle.plugin.dsl.announce.ZulipAnnouncer
@@ -78,6 +79,7 @@ class AnnounceImpl implements Announce {
     final SlackAnnouncerImpl slack
     final TeamsAnnouncerImpl teams
     final TelegramAnnouncerImpl telegram
+    final TwistAnnouncerImpl twist
     final TwitterAnnouncerImpl twitter
     final ZulipAnnouncerImpl zulip
     final NamedDomainObjectContainer<HttpAnnouncer> http
@@ -103,6 +105,7 @@ class AnnounceImpl implements Announce {
         slack = objects.newInstance(SlackAnnouncerImpl, objects)
         teams = objects.newInstance(TeamsAnnouncerImpl, objects)
         telegram = objects.newInstance(TelegramAnnouncerImpl, objects)
+        twist = objects.newInstance(TwistAnnouncerImpl, objects)
         twitter = objects.newInstance(TwitterAnnouncerImpl, objects)
         zulip = objects.newInstance(ZulipAnnouncerImpl, objects)
 
@@ -233,6 +236,11 @@ class AnnounceImpl implements Announce {
     }
 
     @Override
+    void twist(Action<? super TwistAnnouncer> action) {
+        action.execute(twist)
+    }
+
+    @Override
     void twitter(Action<? super TwitterAnnouncer> action) {
         action.execute(twitter)
     }
@@ -267,6 +275,7 @@ class AnnounceImpl implements Announce {
         if (slack.isSet()) announce.slack = slack.toModel()
         if (teams.isSet()) announce.teams = teams.toModel()
         if (telegram.isSet()) announce.telegram = telegram.toModel()
+        if (twist.isSet()) announce.twist = twist.toModel()
         if (twitter.isSet()) announce.twitter = twitter.toModel()
         if (zulip.isSet()) announce.zulip = zulip.toModel()
 

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/announce/TwistAnnouncerImpl.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/announce/TwistAnnouncerImpl.groovy
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2026 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.gradle.plugin.internal.dsl.announce
+
+import groovy.transform.CompileStatic
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.internal.provider.Providers
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.jreleaser.gradle.plugin.dsl.announce.TwistAnnouncer
+
+import javax.inject.Inject
+
+/**
+ *
+ * @author Usman Shaikh
+ * @since 1.23.0
+ */
+@CompileStatic
+class TwistAnnouncerImpl extends AbstractAnnouncer implements TwistAnnouncer {
+    final Property<String> webhook
+    final RegularFileProperty messageTemplate
+
+    @Inject
+    TwistAnnouncerImpl(ObjectFactory objects) {
+        super(objects)
+        webhook = objects.property(String).convention(Providers.<String> notDefined())
+        messageTemplate = objects.fileProperty().convention(Providers.notDefined())
+    }
+
+    @Override
+    void setMessageTemplate(String messageTemplate) {
+        this.messageTemplate.set(new File(messageTemplate))
+    }
+
+    @Override
+    @Internal
+    boolean isSet() {
+        super.isSet() ||
+            webhook.present ||
+            messageTemplate.present
+    }
+
+    org.jreleaser.model.internal.announce.TwistAnnouncer toModel() {
+        org.jreleaser.model.internal.announce.TwistAnnouncer announcer = new org.jreleaser.model.internal.announce.TwistAnnouncer()
+        fillProperties(announcer)
+        if (webhook.present) announcer.webhook = webhook.get()
+        if (messageTemplate.present) {
+            announcer.messageTemplate = messageTemplate.asFile.get().absolutePath
+        }
+        announcer
+    }
+}

--- a/sdks/jreleaser-twist-java-sdk/gradle.properties
+++ b/sdks/jreleaser-twist-java-sdk/gradle.properties
@@ -1,0 +1,20 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2020-2026 The JReleaser authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+project_description = Java SDK for Twist
+automatic.module.name = org.jreleaser.sdk.twist

--- a/sdks/jreleaser-twist-java-sdk/jreleaser-twist-java-sdk.gradle
+++ b/sdks/jreleaser-twist-java-sdk/jreleaser-twist-java-sdk.gradle
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2026 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+dependencies {
+    compileOnly "org.kordamp.jipsy:jipsy-annotations:${jipsyVersion}"
+    annotationProcessor "org.kordamp.jipsy:jipsy-processor:${jipsyVersion}"
+
+    api project(':jreleaser-webhooks-java-sdk')
+}

--- a/sdks/jreleaser-twist-java-sdk/src/main/java/org/jreleaser/sdk/twist/TwistAnnouncer.java
+++ b/sdks/jreleaser-twist-java-sdk/src/main/java/org/jreleaser/sdk/twist/TwistAnnouncer.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2026 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.sdk.twist;
+
+import org.jreleaser.model.internal.JReleaserContext;
+import org.jreleaser.model.spi.announce.AnnounceException;
+import org.jreleaser.model.spi.announce.Announcer;
+import org.jreleaser.sdk.webhooks.WebhooksAnnouncer;
+
+/**
+ * @author Usman Shaikh
+ * @since 1.23.0
+ */
+@org.jreleaser.infra.nativeimage.annotations.NativeImage
+public class TwistAnnouncer implements Announcer<org.jreleaser.model.api.announce.TwistAnnouncer> {
+    private final JReleaserContext context;
+    private final org.jreleaser.model.internal.announce.TwistAnnouncer twist;
+
+    public TwistAnnouncer(JReleaserContext context) {
+        this.context = context;
+        this.twist = context.getModel().getAnnounce().getTwist();
+    }
+
+    @Override
+    public org.jreleaser.model.api.announce.TwistAnnouncer getAnnouncer() {
+        return twist.asImmutable();
+    }
+
+    @Override
+    public String getName() {
+        return org.jreleaser.model.api.announce.TwistAnnouncer.TYPE;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return twist.isEnabled();
+    }
+
+    @Override
+    public void announce() throws AnnounceException {
+        context.getLogger().setPrefix("webhook."  + getName());
+        try {
+            WebhooksAnnouncer.announce(context, twist.asWebhookAnnouncer(), true);
+        } catch (AnnounceException e) {
+            context.getLogger().warn(e.getMessage().trim());
+        } finally {
+            context.getLogger().restorePrefix();
+        }
+    }
+}

--- a/sdks/jreleaser-twist-java-sdk/src/main/java/org/jreleaser/sdk/twist/TwistAnnouncerBuilder.java
+++ b/sdks/jreleaser-twist-java-sdk/src/main/java/org/jreleaser/sdk/twist/TwistAnnouncerBuilder.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2026 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.sdk.twist;
+
+import org.jreleaser.model.spi.announce.AbstractAnnouncerBuilder;
+
+/**
+ * @author Usman Shaikh
+ * @since 1.23.0
+ */
+public class TwistAnnouncerBuilder extends AbstractAnnouncerBuilder<TwistAnnouncer> {
+    @Override
+    public TwistAnnouncer build() {
+        validate();
+
+        return new TwistAnnouncer(context);
+    }
+}

--- a/sdks/jreleaser-twist-java-sdk/src/main/java/org/jreleaser/sdk/twist/TwistAnnouncerBuilderFactory.java
+++ b/sdks/jreleaser-twist-java-sdk/src/main/java/org/jreleaser/sdk/twist/TwistAnnouncerBuilderFactory.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2026 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.sdk.twist;
+
+import org.jreleaser.model.spi.announce.AnnouncerBuilderFactory;
+import org.kordamp.jipsy.annotations.ServiceProviderFor;
+
+/**
+ * @author Usman Shaikh
+ * @since 1.23.0
+ */
+@ServiceProviderFor(AnnouncerBuilderFactory.class)
+public class TwistAnnouncerBuilderFactory implements AnnouncerBuilderFactory<TwistAnnouncer, TwistAnnouncerBuilder> {
+    @Override
+    public String getName() {
+        return org.jreleaser.model.api.announce.TwistAnnouncer.TYPE;
+    }
+
+    @Override
+    public TwistAnnouncerBuilder getBuilder() {
+        return new TwistAnnouncerBuilder();
+    }
+}


### PR DESCRIPTION
Fixes #1662 

### Context
- Supports posting to a channel using a channel webhook [integration](https://developer.twist.com/v3/#channel-updates).
- Supports replying to a thread using thread webhook [integration](https://developer.twist.com/v3/#thread-updates).

#### JReleaser config file
```
announce:
  twist:
    active: ALWAYS
    webhook: https://twist.com/api/v3/integration_incoming/post_data?install_id=redacted&install_token=redacted
    messageTemplate: src/jreleaser/templates/twist-channel.tpl
```

#### twist-channel.tpl 
```
{
  "content": "**{{projectName}} {{projectVersion}} is now available!**\n\n{{projectLongDescription}}\n\nReleased with JReleaser",
  "title": "{{projectName}} {{projectVersion}} is now available!"
}
```

#### twist-thread.tpl
```
{
  "content": "**{{projectName}} {{projectVersion}} is now available!**\n\n{{projectLongDescription}}\n\nReleased with JReleaser",
}
```

### Checklist
- [✔️] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [✔️] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
