### PR TITLE
feat(changelog): support path filtering for monorepo changelog generation

### DIFF
--- a/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/release/Changelog.java
+++ b/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/release/Changelog.java
@@ -63,6 +63,8 @@ public interface Changelog extends Domain, EnabledAware, ExtraProperties {
 
     String getPreset();
 
+    Set<String> getPaths();
+
     Hide getHide();
 
     Contributors getContributors();

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/release/Changelog.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/release/Changelog.java
@@ -58,7 +58,7 @@ import static org.jreleaser.util.StringUtils.normalizeRegexPattern;
  * @since 0.1.0
  */
 public final class Changelog extends AbstractModelObject<Changelog> implements Domain, EnabledAware, ExtraProperties {
-    private static final long serialVersionUID = -2693712593082430980L;
+    private static final long serialVersionUID = -2693712593082430981L;
 
     private final Map<String, Object> extraProperties = new LinkedHashMap<>();
     private final Set<String> includeLabels = new LinkedHashSet<>();
@@ -69,6 +69,7 @@ public final class Changelog extends AbstractModelObject<Changelog> implements D
     private final Hide hide = new Hide();
     private final Contributors contributors = new Contributors();
     private final Append append = new Append();
+    private final Set<String> paths = new LinkedHashSet<>();
 
     private Boolean enabled;
     private Boolean links;
@@ -212,6 +213,11 @@ public final class Changelog extends AbstractModelObject<Changelog> implements D
         }
 
         @Override
+        public Set<String> getPaths() {
+            return unmodifiableSet(paths);
+        }
+
+        @Override
         public Map<String, Object> asMap(boolean full) {
             return unmodifiableMap(Changelog.this.asMap(full));
         }
@@ -232,6 +238,7 @@ public final class Changelog extends AbstractModelObject<Changelog> implements D
             !categories.isEmpty() ||
             !replacers.isEmpty() ||
             !labelers.isEmpty() ||
+            !paths.isEmpty() ||
             hide.isSet() ||
             contributors.isSet() ||
             append.isSet() ||
@@ -268,6 +275,7 @@ public final class Changelog extends AbstractModelObject<Changelog> implements D
         setCategories(merge(this.categories, source.categories));
         setReplacers(merge(this.replacers, source.replacers));
         setLabelers(merge(this.labelers, source.labelers));
+        setPaths(merge(this.paths, source.paths));
         setHide(source.hide);
         setContributors(source.contributors);
         setAppend(source.append);
@@ -414,6 +422,15 @@ public final class Changelog extends AbstractModelObject<Changelog> implements D
         this.labelers.addAll(labelers);
     }
 
+    public Set<String> getPaths() {
+        return paths;
+    }
+
+    public void setPaths(Set<String> paths) {
+        this.paths.clear();
+        this.paths.addAll(paths.stream().map(String::trim).collect(toSet()));
+    }
+
     public String getFormat() {
         return format;
     }
@@ -522,6 +539,7 @@ public final class Changelog extends AbstractModelObject<Changelog> implements D
         map.put("contentTemplate", contentTemplate);
         map.put("includeLabels", includeLabels);
         map.put("excludeLabels", excludeLabels);
+        map.put("paths", paths);
         map.put("hide", hide.asMap(full));
         map.put("contributors", contributors.asMap(full));
 

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/dsl/release/Changelog.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/dsl/release/Changelog.groovy
@@ -68,9 +68,13 @@ interface Changelog extends ExtraProperties {
 
     SetProperty<String> getExcludeLabels()
 
+    SetProperty<String> getPaths()
+
     void includeLabel(String label)
 
     void excludeLabel(String label)
+
+    void path(String path)
 
     void category(Action<? super Category> action)
 

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/release/ChangelogImpl.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/release/ChangelogImpl.groovy
@@ -56,6 +56,7 @@ class ChangelogImpl implements Changelog {
     final RegularFileProperty contentTemplate
     final SetProperty<String> includeLabels
     final SetProperty<String> excludeLabels
+    final SetProperty<String> paths
     final HideImpl hide
     final ContributorsImpl contributors
     final AppendImpl append
@@ -84,6 +85,7 @@ class ChangelogImpl implements Changelog {
         contentTemplate = objects.fileProperty().convention(Providers.notDefined())
         includeLabels = objects.setProperty(String).convention(Providers.<Set<String>> notDefined())
         excludeLabels = objects.setProperty(String).convention(Providers.<Set<String>> notDefined())
+        paths = objects.setProperty(String).convention(Providers.<Set<String>> notDefined())
         hide = objects.newInstance(HideImpl, objects)
         contributors = objects.newInstance(ContributorsImpl, objects)
         append = objects.newInstance(AppendImpl, objects)
@@ -123,6 +125,7 @@ class ChangelogImpl implements Changelog {
             contentTemplate.present ||
             includeLabels.present ||
             excludeLabels.present ||
+            paths.present ||
             !categories.isEmpty() ||
             !labelers.isEmpty() ||
             !replacers.isEmpty() ||
@@ -148,6 +151,13 @@ class ChangelogImpl implements Changelog {
     void excludeLabel(String label) {
         if (isNotBlank(label)) {
             excludeLabels.add(label.trim())
+        }
+    }
+
+    @Override
+    void path(String path) {
+        if (isNotBlank(path)) {
+            paths.add(path.trim())
         }
     }
 
@@ -213,6 +223,7 @@ class ChangelogImpl implements Changelog {
         }
         changelog.includeLabels = (Set<String>) includeLabels.getOrElse([] as Set)
         changelog.excludeLabels = (Set<String>) excludeLabels.getOrElse([] as Set)
+        changelog.paths = (Set<String>) paths.getOrElse([] as Set)
         changelog.setCategories(categories.collect([]) { CategoryImpl category ->
             category.toModel()
         } as Set<org.jreleaser.model.internal.release.Changelog.Category>)


### PR DESCRIPTION
When using JReleaser in a monorepo with multiple projects, the changelog includes commits from the entire repository rather than just the project being released.

This PR adds a `paths` property to the changelog configuration that filters commits to only those affecting the specified paths using JGit's `LogCommand.addPath()`.

**Usage:**
```yaml
release:
  github:
    changelog:
      paths:
        - 'my-subproject/'
```

Closes #2072