### PR TITLE
Fix misleading message from disabled deployer

### DIFF
--- a/api/jreleaser-resource-bundle/src/main/resources/org/jreleaser/bundle/Messages.properties
+++ b/api/jreleaser-resource-bundle/src/main/resources/org/jreleaser/bundle/Messages.properties
@@ -182,7 +182,6 @@ ERROR_password_incorrect             = Password does not match
 ERROR_unexpected_error_timestamp_file = Unexpected error when checking last modified timestamp for {}
 ERROR_public_key_expired             = Signing key {} expired at {}
 
-deployer.disabled                   = Deployer {}.{} disabled because project is snapshot
 deployers.maven.header              = Deploying Maven artifacts
 deployers.not.enabled               = Deploying is not enabled. Skipping
 deployers.not.triggered             = No deployers were triggered

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/deploy/maven/MavenDeployersValidator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/deploy/maven/MavenDeployersValidator.java
@@ -122,7 +122,7 @@ public final class MavenDeployersValidator {
                 "deploy.maven." + mavenDeployer.getType()),
             "NEVER");
         if (!mavenDeployer.resolveEnabledWithSnapshot(context.getModel().getProject())) {
-            context.getLogger().warn(RB.$("deployer.disabled", mavenDeployer.getType(), mavenDeployer.getName()));
+            context.getLogger().warn(RB.$("deployers.deployer.disabled", mavenDeployer.getType(), mavenDeployer.getName()));
             context.getLogger().debug(RB.$("validation.disabled"));
             return;
         }


### PR DESCRIPTION
The reason (`because project is snapshot`) is not true when the disabled deployer is configured as `active: SNAPSHOT` and the project is NOT a SNAPSHOT
eg.
```
[WARN]    [validation] Deployer nexus2.maven-central disabled because project is snapshot
```
