### PR TITLE
feat(gradle): Fix access to Task.project at task execution time

### DIFF
--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/JReleaserExtension.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/JReleaserExtension.groovy
@@ -40,6 +40,9 @@ import org.jreleaser.gradle.plugin.dsl.project.Project
 import org.jreleaser.gradle.plugin.dsl.release.Release
 import org.jreleaser.gradle.plugin.dsl.signing.Signing
 import org.jreleaser.gradle.plugin.dsl.upload.Upload
+import org.jreleaser.gradle.plugin.internal.JReleaserGradleProjectCapture
+import org.jreleaser.logging.JReleaserLogger
+import org.jreleaser.model.internal.JReleaserModel
 
 /**
  *
@@ -97,6 +100,8 @@ interface JReleaserExtension {
     Signing getSigning()
 
     Checksum getChecksum()
+
+    JReleaserModel toModel(JReleaserGradleProjectCapture gradleProjectCapture, JReleaserLogger logger)
 
     // NamedDomainObjectContainer<Extension> getExtensions()
 

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/JReleaserPlugin.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/JReleaserPlugin.groovy
@@ -124,9 +124,6 @@ class JReleaserPlugin implements Plugin<Project> {
                 void execute(JReleaserEnvTask t) {
                     t.group = JRELEASER_GROUP
                     t.description = 'Display environment variable names'
-                    t.basedir.set(project.layout.projectDirectory)
-                    t.jlogger.set(new JReleaserLoggerAdapter(new AnsiConsole(project, 'JRELEASER'), LogLevel.INFO,
-                        newPrintWriter(new ByteArrayOutputStream())))
                 }
             })
 

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/JReleaserExtensionImpl.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/JReleaserExtensionImpl.groovy
@@ -264,19 +264,20 @@ class JReleaserExtensionImpl implements JReleaserExtension {
     }
 
     @CompileDynamic
-    JReleaserModel toModel(org.gradle.api.Project gradleProject, JReleaserLogger logger) {
+    @Override
+    JReleaserModel toModel(JReleaserGradleProjectCapture gradleProjectCapture, JReleaserLogger logger) {
         if (configFile.present) {
             JReleaserModel jreleaser = ContextCreator.resolveModel(logger, configFile.asFile.get().toPath())
-            if (isBlank(jreleaser.project.name)) jreleaser.project.name = gradleProject.name
-            if (isBlank(jreleaser.project.version)) jreleaser.project.version = gradleProject.version
-            if (isBlank(jreleaser.project.description)) jreleaser.project.description = gradleProject.description
+            if (isBlank(jreleaser.project.name)) jreleaser.project.name = gradleProjectCapture.name
+            if (isBlank(jreleaser.project.version)) jreleaser.project.version = gradleProjectCapture.version
+            if (isBlank(jreleaser.project.description)) jreleaser.project.description = gradleProjectCapture.description
             jreleaser.environment.propertiesSource = new org.jreleaser.model.internal.environment.Environment.MapPropertiesSource(
-                filterProperties(gradleProject.properties))
+                filterProperties(gradleProjectCapture.properties))
             return jreleaser
         }
 
         JReleaserModel jreleaser = new JReleaserModel()
-        jreleaser.environment = environment.toModel(gradleProject)
+        jreleaser.environment = environment.toModel(gradleProjectCapture)
         jreleaser.setMatrix(matrix.toModel())
         jreleaser.hooks = hooks.toModel()
         jreleaser.project = project.toModel()

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/JReleaserGradleProjectCapture.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/JReleaserGradleProjectCapture.groovy
@@ -1,0 +1,135 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2026 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.gradle.plugin.internal
+
+import org.gradle.api.Project
+import org.gradle.api.plugins.ExtraPropertiesExtension
+import org.gradle.api.plugins.JavaApplication
+import org.gradle.api.provider.Provider
+import org.jreleaser.logging.JReleaserLogger
+
+/**
+ * Captures relevant information from a Gradle Project
+ * to be used in JReleaser plugin configuration and tasks.
+ *
+ * @author Markus Hoffrogge
+ * @since 1.24.0
+ */
+class JReleaserGradleProjectCapture implements Serializable {
+    final String group
+    final String version
+    final String name
+    final String description
+    final boolean multiProject
+    final String javaApplicationMainClass
+    final String javaApplicationMainModule
+
+    private final Map<String, Serializable> properties
+
+    // List of Gradle Project properties that are deprecated in Gradle 9
+    // and should be ignored to avoid deprecation warnings.
+    private static final List<String> GRADLE_DEPRECATED_PROJECT_PROPS = [
+        'archivesBaseName',
+        'archivesName',
+        'autoTargetJvmDisabled',
+        'convention',
+        'distsDirectory',
+        'distsDirName',
+        'docsDir',
+        'docsDirName',
+        'libsDirectory',
+        'libsDirName',
+        'testReportDir',
+        'testReportDirName',
+        'testResultsDir',
+        'testResultsDirName'
+    ]
+
+    static JReleaserGradleProjectCapture of(Project gradleProject, JReleaserLogger logger) {
+        return new JReleaserGradleProjectCapture(gradleProject, logger)
+    }
+
+    private JReleaserGradleProjectCapture(Project gradleProject, JReleaserLogger logger) {
+        this.name = gradleProject.name
+        this.group = gradleProject.group?.toString()
+        this.version = gradleProject.version?.toString()
+        this.description = gradleProject.description
+        this.properties = captureGradleProjectSerializableProperties(gradleProject, logger)
+        this.multiProject = !gradleProject.rootProject.childProjects.isEmpty()
+        JavaApplication javaApplication = (JavaApplication) gradleProject.extensions.findByType(JavaApplication)
+        this.javaApplicationMainClass = javaApplication?.mainClass?.orNull
+        this.javaApplicationMainModule = javaApplication?.mainModule?.orNull
+    }
+
+    private static Map <String, Serializable> captureGradleProjectSerializableProperties(
+        Project gradleProject, JReleaserLogger logger) {
+        Set<String> propertyKeys = collectGradleProjectPropertyKeys(gradleProject)
+        Map <String, Serializable> projectProperties = [:]
+        propertyKeys.each { key ->
+            // Avoid useless Gradle deprecation log
+            if (GRADLE_DEPRECATED_PROJECT_PROPS.contains(key)) {
+                logger.debug("GradleProjectCapture: IGNORE deprecated Gradle project property '${key}'.")
+                return // continue
+            }
+            Object value = gradleProject.findProperty(key)
+            if (value instanceof Provider) {
+                Provider p = (Provider) value
+                value = p.present ? p.get() : null
+            }
+            if (value instanceof File) {
+                value = ((File) value).absolutePath
+            }
+            if (value instanceof CharSequence || value instanceof Number || value instanceof Boolean) {
+                logger.debug("GradleProjectCapture: CAPTURE project property '${key}'.")
+                projectProperties.put(key, value instanceof Serializable ? (Serializable) value : value.toString())
+            } else if (value) {
+                logger.debug("GradleProjectCapture: SKIP complex project property '${key}' of type '${value.getClass().name}'.")
+            } else {
+                logger.debug("GradleProjectCapture: SKIP null or empty project property '${key}'.")
+            }
+        }
+        return projectProperties
+    }
+
+    private static Set<String> collectGradleProjectPropertyKeys(Project gradleProject) {
+        Set<String> propertyKeys = gradleProject.properties.keySet()
+        ExtraPropertiesExtension extraPropertiesExtension = gradleProject.extensions.extraProperties
+        Set<String> extraPropertyKeys = extraPropertiesExtension?.properties?.keySet()
+        if (extraPropertyKeys) {
+            propertyKeys += extraPropertyKeys
+            propertyKeys = propertyKeys.toSet()
+        }
+        return propertyKeys
+    }
+
+    Map<String, Serializable> getProperties() {
+        return properties.asImmutable()
+    }
+
+    Serializable findProperty(String propertyName) {
+        return hasProperty(propertyName) ? property(propertyName) : null;
+    }
+
+    boolean hasProperty(String propertyName) {
+        return properties.containsKey(propertyName)
+    }
+
+    Serializable property(String propertyName) {
+        return properties[propertyName]
+    }
+}

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/JReleaserProjectConfigurer.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/JReleaserProjectConfigurer.groovy
@@ -23,29 +23,10 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.Directory
-import org.gradle.api.plugins.JavaApplication
+import org.gradle.api.invocation.Gradle
 import org.gradle.api.provider.Provider
 import org.gradle.api.services.BuildServiceSpec
 import org.jreleaser.gradle.plugin.JReleaserExtension
-import org.jreleaser.gradle.plugin.tasks.JReleaseAutoConfigReleaseTask
-import org.jreleaser.gradle.plugin.tasks.JReleaserAnnounceTask
-import org.jreleaser.gradle.plugin.tasks.JReleaserAssembleTask
-import org.jreleaser.gradle.plugin.tasks.JReleaserCatalogTask
-import org.jreleaser.gradle.plugin.tasks.JReleaserChangelogTask
-import org.jreleaser.gradle.plugin.tasks.JReleaserChecksumTask
-import org.jreleaser.gradle.plugin.tasks.JReleaserConfigTask
-import org.jreleaser.gradle.plugin.tasks.JReleaserDeployTask
-import org.jreleaser.gradle.plugin.tasks.JReleaserDownloadTask
-import org.jreleaser.gradle.plugin.tasks.JReleaserFullReleaseTask
-import org.jreleaser.gradle.plugin.tasks.JReleaserInitTask
-import org.jreleaser.gradle.plugin.tasks.JReleaserPackageTask
-import org.jreleaser.gradle.plugin.tasks.JReleaserPrepareTask
-import org.jreleaser.gradle.plugin.tasks.JReleaserPublishTask
-import org.jreleaser.gradle.plugin.tasks.JReleaserReleaseTask
-import org.jreleaser.gradle.plugin.tasks.JReleaserSignTask
-import org.jreleaser.gradle.plugin.tasks.JReleaserTemplateEvalTask
-import org.jreleaser.gradle.plugin.tasks.JReleaserTemplateGenerateTask
-import org.jreleaser.gradle.plugin.tasks.JReleaserUploadTask
 import org.jreleaser.model.internal.JReleaserModel
 import org.kordamp.gradle.util.AnsiConsole
 
@@ -60,22 +41,31 @@ import static org.kordamp.gradle.util.StringUtils.isBlank
 class JReleaserProjectConfigurer {
     static final String ASSEMBLE_DIST_TASK_NAME = 'assembleDist'
 
-    static void configure(Project project) {
-        JReleaserExtensionImpl extension = (JReleaserExtensionImpl) project.extensions.findByType(JReleaserExtension)
+    static JReleaserExtension getJReleaserExtension(Project gradleProject) {
+        return gradleProject.extensions.findByType(JReleaserExtension)
+    }
 
-        boolean hasDistributionPlugin = extension.dependsOnAssemble.getOrElse(true) && configureDefaultDistribution(project, extension)
-
-        Provider<Directory> outputDirectory = project.layout.buildDirectory
+    static Provider<Directory> getJReleaserOutputDirectoryProvider(Project gradleProject) {
+        return gradleProject.layout.buildDirectory
             .dir('jreleaser')
+    }
 
-        Provider<JReleaserLoggerService> loggerProvider = project.gradle.sharedServices
-            .registerIfAbsent('jreleaserLogger', JReleaserLoggerService.class) { BuildServiceSpec<JReleaserLoggerService.Params> spec ->
-                spec.parameters.console.set(new AnsiConsole(project, 'JRELEASER'))
-                spec.parameters.logLevel.set(project.gradle.startParameter.logLevel)
-                spec.parameters.outputDirectory.set(outputDirectory)
-            }
+    static Provider<JReleaserLoggerService> getJReleaserLoggerServiceProvider(Project gradleProject) {
+        Gradle gradle = gradleProject.gradle
+        Provider<Directory> outputDirectoryProvider = getJReleaserOutputDirectoryProvider(gradleProject)
+        return gradle.sharedServices.registerIfAbsent(
+            "jreleaserLogger_${gradleProject.path.replace(':', '_')}",
+            JReleaserLoggerService.class) {
+            BuildServiceSpec<JReleaserLoggerService.Params> spec ->
+                spec.parameters.console.set(new AnsiConsole(gradle, 'JRELEASER'))
+                spec.parameters.logLevel.set(gradle.startParameter.logLevel)
+                spec.parameters.outputDirectory.set(outputDirectoryProvider)
+        }
+    }
 
-        project.tasks.named('clean', new Action<Task>() {
+    static void configure(Project gradleProject) {
+        Provider<JReleaserLoggerService> loggerProvider = getJReleaserLoggerServiceProvider(gradleProject)
+        gradleProject.tasks.named('clean', new Action<Task>() {
             @Override
             void execute(Task t) {
                 t.doFirst(new Action<Task>() {
@@ -87,318 +77,32 @@ class JReleaserProjectConfigurer {
             }
         })
 
-        project.tasks.named(JReleaserConfigTask.NAME, JReleaserConfigTask,
-            new Action<JReleaserConfigTask>() {
-                @Override
-                void execute(JReleaserConfigTask t) {
-                    t.outputDirectory.set(outputDirectory)
-                    t.yolo.set(extension.yolo)
-                    t.dryrun.set(extension.dryrun)
-                    t.gitRootSearch.set(extension.gitRootSearch)
-                    t.strict.set(extension.strict)
-                    t.jlogger.set(loggerProvider)
-                    t.usesService(loggerProvider)
-                    if (hasDistributionPlugin) {
-                        t.dependsOn(ASSEMBLE_DIST_TASK_NAME)
-                    }
-                }
-            })
-
-        project.tasks.named(JReleaserTemplateGenerateTask.NAME, JReleaserTemplateGenerateTask,
-            new Action<JReleaserTemplateGenerateTask>() {
-                @Override
-                void execute(JReleaserTemplateGenerateTask t) {
-                    t.jlogger.set(loggerProvider)
-                    t.usesService(loggerProvider)
-                }
-            })
-
-        project.tasks.named(JReleaserTemplateEvalTask.NAME, JReleaserTemplateEvalTask,
-            new Action<JReleaserTemplateEvalTask>() {
-                @Override
-                void execute(JReleaserTemplateEvalTask t) {
-                    t.outputDirectory.set(outputDirectory)
-                    t.jlogger.set(loggerProvider)
-                    t.usesService(loggerProvider)
-                }
-            })
-
-        project.tasks.named(JReleaserDownloadTask.NAME, JReleaserDownloadTask,
-            new Action<JReleaserDownloadTask>() {
-                @Override
-                void execute(JReleaserDownloadTask t) {
-                    t.outputDirectory.set(outputDirectory)
-                    t.yolo.set(extension.yolo)
-                    t.dryrun.set(extension.dryrun)
-                    t.gitRootSearch.set(extension.gitRootSearch)
-                    t.strict.set(extension.strict)
-                    t.jlogger.set(loggerProvider)
-                    t.usesService(loggerProvider)
-                }
-            })
-
-        project.tasks.named(JReleaserAssembleTask.NAME, JReleaserAssembleTask,
-            new Action<JReleaserAssembleTask>() {
-                @Override
-                void execute(JReleaserAssembleTask t) {
-                    t.outputDirectory.set(outputDirectory)
-                    t.yolo.set(extension.yolo)
-                    t.dryrun.set(extension.dryrun)
-                    t.gitRootSearch.set(extension.gitRootSearch)
-                    t.strict.set(extension.strict)
-                    t.jlogger.set(loggerProvider)
-                    t.usesService(loggerProvider)
-                }
-            })
-
-        project.tasks.named(JReleaserChangelogTask.NAME, JReleaserChangelogTask,
-            new Action<JReleaserChangelogTask>() {
-                @Override
-                void execute(JReleaserChangelogTask t) {
-                    t.outputDirectory.set(outputDirectory)
-                    t.yolo.set(extension.yolo)
-                    t.dryrun.set(extension.dryrun)
-                    t.gitRootSearch.set(extension.gitRootSearch)
-                    t.strict.set(extension.strict)
-                    t.jlogger.set(loggerProvider)
-                    t.usesService(loggerProvider)
-                }
-            })
-
-        project.tasks.named(JReleaserChecksumTask.NAME, JReleaserChecksumTask,
-            new Action<JReleaserChecksumTask>() {
-                @Override
-                void execute(JReleaserChecksumTask t) {
-                    t.outputDirectory.set(outputDirectory)
-                    t.yolo.set(extension.yolo)
-                    t.dryrun.set(extension.dryrun)
-                    t.gitRootSearch.set(extension.gitRootSearch)
-                    t.strict.set(extension.strict)
-                    t.jlogger.set(loggerProvider)
-                    t.usesService(loggerProvider)
-                    if (hasDistributionPlugin) {
-                        t.dependsOn(ASSEMBLE_DIST_TASK_NAME)
-                    }
-                }
-            })
-
-        project.tasks.named(JReleaserSignTask.NAME, JReleaserSignTask,
-            new Action<JReleaserSignTask>() {
-                @Override
-                void execute(JReleaserSignTask t) {
-                    t.outputDirectory.set(outputDirectory)
-                    t.yolo.set(extension.yolo)
-                    t.dryrun.set(extension.dryrun)
-                    t.gitRootSearch.set(extension.gitRootSearch)
-                    t.strict.set(extension.strict)
-                    t.jlogger.set(loggerProvider)
-                    t.usesService(loggerProvider)
-                    if (hasDistributionPlugin) {
-                        t.dependsOn(ASSEMBLE_DIST_TASK_NAME)
-                    }
-                }
-            })
-
-        project.tasks.named(JReleaserDeployTask.NAME, JReleaserDeployTask,
-            new Action<JReleaserDeployTask>() {
-                @Override
-                void execute(JReleaserDeployTask t) {
-                    t.outputDirectory.set(outputDirectory)
-                    t.yolo.set(extension.yolo)
-                    t.dryrun.set(extension.dryrun)
-                    t.gitRootSearch.set(extension.gitRootSearch)
-                    t.strict.set(extension.strict)
-                    t.jlogger.set(loggerProvider)
-                    t.usesService(loggerProvider)
-                }
-            })
-
-        project.tasks.named(JReleaserCatalogTask.NAME, JReleaserCatalogTask,
-            new Action<JReleaserCatalogTask>() {
-                @Override
-                void execute(JReleaserCatalogTask t) {
-                    t.outputDirectory.set(outputDirectory)
-                    t.yolo.set(extension.yolo)
-                    t.dryrun.set(extension.dryrun)
-                    t.gitRootSearch.set(extension.gitRootSearch)
-                    t.strict.set(extension.strict)
-                    t.jlogger.set(loggerProvider)
-                    t.usesService(loggerProvider)
-                }
-            })
-
-        project.tasks.named(JReleaserUploadTask.NAME, JReleaserUploadTask,
-            new Action<JReleaserUploadTask>() {
-                @Override
-                void execute(JReleaserUploadTask t) {
-                    t.outputDirectory.set(outputDirectory)
-                    t.yolo.set(extension.yolo)
-                    t.dryrun.set(extension.dryrun)
-                    t.gitRootSearch.set(extension.gitRootSearch)
-                    t.strict.set(extension.strict)
-                    t.jlogger.set(loggerProvider)
-                    t.usesService(loggerProvider)
-                    if (hasDistributionPlugin) {
-                        t.dependsOn(ASSEMBLE_DIST_TASK_NAME)
-                    }
-                }
-            })
-
-        project.tasks.named(JReleaserReleaseTask.NAME, JReleaserReleaseTask,
-            new Action<JReleaserReleaseTask>() {
-                @Override
-                void execute(JReleaserReleaseTask t) {
-                    t.outputDirectory.set(outputDirectory)
-                    t.yolo.set(extension.yolo)
-                    t.dryrun.set(extension.dryrun)
-                    t.gitRootSearch.set(extension.gitRootSearch)
-                    t.strict.set(extension.strict)
-                    t.jlogger.set(loggerProvider)
-                    t.usesService(loggerProvider)
-                    if (hasDistributionPlugin) {
-                        t.dependsOn(ASSEMBLE_DIST_TASK_NAME)
-                    }
-                }
-            })
-
-        project.tasks.named(JReleaseAutoConfigReleaseTask.NAME, JReleaseAutoConfigReleaseTask,
-            new Action<JReleaseAutoConfigReleaseTask>() {
-                @Override
-                void execute(JReleaseAutoConfigReleaseTask t) {
-                    t.outputDirectory.set(outputDirectory)
-                    t.yolo.set(extension.yolo)
-                    t.dryrun.set(extension.dryrun)
-                    t.gitRootSearch.set(extension.gitRootSearch)
-                    t.strict.set(extension.strict)
-                    t.jlogger.set(loggerProvider)
-                    t.usesService(loggerProvider)
-                }
-            })
-
-        project.tasks.named(JReleaserPrepareTask.NAME, JReleaserPrepareTask,
-            new Action<JReleaserPrepareTask>() {
-                @Override
-                void execute(JReleaserPrepareTask t) {
-                    t.outputDirectory.set(outputDirectory)
-                    t.yolo.set(extension.yolo)
-                    t.dryrun.set(extension.dryrun)
-                    t.gitRootSearch.set(extension.gitRootSearch)
-                    t.strict.set(extension.strict)
-                    t.jlogger.set(loggerProvider)
-                    t.usesService(loggerProvider)
-                    if (hasDistributionPlugin) {
-                        t.dependsOn(ASSEMBLE_DIST_TASK_NAME)
-                    }
-                }
-            })
-
-        project.tasks.named(JReleaserPackageTask.NAME, JReleaserPackageTask,
-            new Action<JReleaserPackageTask>() {
-                @Override
-                void execute(JReleaserPackageTask t) {
-                    t.outputDirectory.set(outputDirectory)
-                    t.yolo.set(extension.yolo)
-                    t.dryrun.set(extension.dryrun)
-                    t.gitRootSearch.set(extension.gitRootSearch)
-                    t.strict.set(extension.strict)
-                    t.jlogger.set(loggerProvider)
-                    t.usesService(loggerProvider)
-                    if (hasDistributionPlugin) {
-                        t.dependsOn(ASSEMBLE_DIST_TASK_NAME)
-                    }
-                }
-            })
-
-        project.tasks.named(JReleaserPublishTask.NAME, JReleaserPublishTask,
-            new Action<JReleaserPublishTask>() {
-                @Override
-                void execute(JReleaserPublishTask t) {
-                    t.outputDirectory.set(outputDirectory)
-                    t.yolo.set(extension.yolo)
-                    t.dryrun.set(extension.dryrun)
-                    t.gitRootSearch.set(extension.gitRootSearch)
-                    t.strict.set(extension.strict)
-                    t.jlogger.set(loggerProvider)
-                    t.usesService(loggerProvider)
-                    if (hasDistributionPlugin) {
-                        t.dependsOn(ASSEMBLE_DIST_TASK_NAME)
-                    }
-                }
-            })
-
-        project.tasks.named(JReleaserAnnounceTask.NAME, JReleaserAnnounceTask,
-            new Action<JReleaserAnnounceTask>() {
-                @Override
-                void execute(JReleaserAnnounceTask t) {
-                    t.outputDirectory.set(outputDirectory)
-                    t.yolo.set(extension.yolo)
-                    t.dryrun.set(extension.dryrun)
-                    t.gitRootSearch.set(extension.gitRootSearch)
-                    t.strict.set(extension.strict)
-                    t.jlogger.set(loggerProvider)
-                    t.usesService(loggerProvider)
-                    if (hasDistributionPlugin) {
-                        t.dependsOn(ASSEMBLE_DIST_TASK_NAME)
-                    }
-                }
-            })
-
-        project.tasks.named(JReleaserFullReleaseTask.NAME, JReleaserFullReleaseTask,
-            new Action<JReleaserFullReleaseTask>() {
-                @Override
-                void execute(JReleaserFullReleaseTask t) {
-                    t.outputDirectory.set(outputDirectory)
-                    t.yolo.set(extension.yolo)
-                    t.dryrun.set(extension.dryrun)
-                    t.gitRootSearch.set(extension.gitRootSearch)
-                    t.strict.set(extension.strict)
-                    t.jlogger.set(loggerProvider)
-                    t.usesService(loggerProvider)
-                    if (hasDistributionPlugin) {
-                        t.dependsOn(ASSEMBLE_DIST_TASK_NAME)
-                    }
-                }
-            })
-
-        project.tasks.named(JReleaserInitTask.NAME, JReleaserInitTask,
-            new Action<JReleaserInitTask>() {
-                @Override
-                void execute(JReleaserInitTask t) {
-                    t.jlogger.set(loggerProvider)
-                    t.usesService(loggerProvider)
-                }
-            })
     }
 
-    private static boolean configureDefaultDistribution(Project project, JReleaserExtensionImpl extension) {
-        return project.plugins.findPlugin('distribution')
-    }
-
-    static void configureModel(Project project, JReleaserModel model) {
+    static void configureModel(JReleaserGradleProjectCapture gradleProjectCapture, JReleaserModel model) {
         String javaVersion = ''
-        if (project.hasProperty('targetCompatibility')) {
-            javaVersion = String.valueOf(project.findProperty('targetCompatibility'))
+        if (gradleProjectCapture.hasProperty('targetCompatibility')) {
+            javaVersion = String.valueOf(gradleProjectCapture.findProperty('targetCompatibility'))
         }
-        if (project.hasProperty('compilerRelease')) {
-            javaVersion = String.valueOf(project.findProperty('compilerRelease'))
+        if (gradleProjectCapture.hasProperty('compilerRelease')) {
+            javaVersion = String.valueOf(gradleProjectCapture.findProperty('compilerRelease'))
         }
         if (isBlank(javaVersion)) {
             javaVersion = JavaVersion.current().toString()
         }
 
         if (isBlank(model.project.languages.java.version)) model.project.languages.java.version = javaVersion
-        if (isBlank(model.project.languages.java.artifactId)) model.project.languages.java.artifactId = project.name
-        if (isBlank(model.project.languages.java.groupId)) model.project.languages.java.groupId = project.group.toString()
+        if (isBlank(model.project.languages.java.artifactId)) model.project.languages.java.artifactId = gradleProjectCapture.name
+        if (isBlank(model.project.languages.java.groupId)) model.project.languages.java.groupId = gradleProjectCapture.group
         if (!model.project.languages.java.multiProjectSet) {
-            model.project.languages.java.multiProject = !project.rootProject.childProjects.isEmpty()
+            model.project.languages.java.multiProject = gradleProjectCapture.multiProject
         }
 
         if (isBlank(model.project.languages.java.mainClass)) {
-            JavaApplication application = (JavaApplication) project.extensions.findByType(JavaApplication)
-            if (application) {
-                model.project.languages.java.mainClass = application.mainClass.orNull
-                model.project.languages.java.mainModule = application.mainModule.orNull
-            }
+            model.project.languages.java.mainClass = gradleProjectCapture.javaApplicationMainClass
+        }
+        if (isBlank(model.project.languages.java.mainModule)) {
+            model.project.languages.java.mainModule = gradleProjectCapture.javaApplicationMainModule
         }
     }
 }

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/environment/EnvironmentImpl.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/environment/EnvironmentImpl.groovy
@@ -18,13 +18,13 @@
 package org.jreleaser.gradle.plugin.internal.dsl.environment
 
 import groovy.transform.CompileStatic
-import org.gradle.api.Project
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.internal.provider.Providers
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Provider
 import org.jreleaser.gradle.plugin.dsl.environment.Environment
+import org.jreleaser.gradle.plugin.internal.JReleaserGradleProjectCapture
 
 import javax.inject.Inject
 
@@ -49,10 +49,10 @@ class EnvironmentImpl implements Environment {
         this.variables.set(new File(variables))
     }
 
-    org.jreleaser.model.internal.environment.Environment toModel(Project project) {
+    org.jreleaser.model.internal.environment.Environment toModel(JReleaserGradleProjectCapture gradleProjectCapture) {
         org.jreleaser.model.internal.environment.Environment environment = new org.jreleaser.model.internal.environment.Environment()
         environment.propertiesSource = new org.jreleaser.model.internal.environment.Environment.MapPropertiesSource(
-            filterProperties(project.properties))
+            filterProperties(gradleProjectCapture.properties))
         if (variables.present) environment.variables = variables.asFile.get().absolutePath
         if (properties.present) environment.properties.putAll(properties.get())
         environment

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/AbstractJReleaserDefaultTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/AbstractJReleaserDefaultTask.groovy
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2026 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.gradle.plugin.tasks
+
+import groovy.transform.CompileStatic
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
+import org.jreleaser.gradle.plugin.JReleaserExtension
+import org.jreleaser.gradle.plugin.internal.JReleaserGradleProjectCapture
+import org.jreleaser.gradle.plugin.internal.JReleaserLoggerService
+import org.jreleaser.gradle.plugin.internal.JReleaserProjectConfigurer
+import org.jreleaser.logging.JReleaserLogger
+
+import javax.inject.Inject
+
+/**
+ *
+ * @author Markus Hoffrogge
+ * @since 1.24.0
+ */
+@CompileStatic
+abstract class AbstractJReleaserDefaultTask extends DefaultTask {
+    @Internal
+    final Property<JReleaserExtension> extension
+
+    @Internal
+    final Property<JReleaserLoggerService> jlogger
+
+    @Internal
+    final DirectoryProperty projectDirectory
+
+    @Input
+    final Property<JReleaserGradleProjectCapture> gradleProjectCapture
+
+    @OutputDirectory
+    final DirectoryProperty outputDirectory
+
+    @Inject
+    AbstractJReleaserDefaultTask(ObjectFactory objects) {
+        extension = objects.property(JReleaserExtension)
+        jlogger = objects.property(JReleaserLoggerService)
+        gradleProjectCapture = objects.property(JReleaserGradleProjectCapture)
+        projectDirectory = objects.directoryProperty()
+        outputDirectory = objects.directoryProperty()
+
+        // Configure properties accessing project at configuration time only
+        extension.convention(JReleaserProjectConfigurer.getJReleaserExtension(project))
+        Provider<JReleaserLoggerService> jloggerServiceProvider
+            = JReleaserProjectConfigurer.getJReleaserLoggerServiceProvider(project)
+        jlogger.convention(jloggerServiceProvider)
+        usesService(jloggerServiceProvider)
+        gradleProjectCapture.convention(JReleaserGradleProjectCapture.of(project, jlogger.get().logger))
+        projectDirectory.convention(project.layout.projectDirectory)
+        outputDirectory.convention(JReleaserProjectConfigurer.getJReleaserOutputDirectoryProvider(project))
+    }
+
+    protected void dependOnAssembleDistIfDistributionPluginIsApplied() {
+        // Use project.pluginManager.withPlugin() to defer the dependency configuration until the plugin is actually applied
+        project.pluginManager.withPlugin('distribution') {
+            dependsOn(project.provider {
+                extension.get().dependsOnAssemble.getOrElse(true) ?
+                    [JReleaserProjectConfigurer.ASSEMBLE_DIST_TASK_NAME] :
+                    []
+            })
+        }
+    }
+
+    // For analysis purposes, JReleaserEnvTask has an option implemented to perform it at task execution time.
+    void logClassLoaderURLs() {
+        URLClassLoader classLoader = (URLClassLoader) this.getClass().getClassLoader()
+        JReleaserLogger logger = jlogger.get().logger
+        List<URL> urls = Arrays.asList(classLoader.getURLs())
+        String taskName = this.getClass().simpleName.replace('_Decorated', '')
+        logger.info("====== Task '{}' classLoader URLs[{}] - BEGIN ======", taskName, urls.size())
+        urls.eachWithIndex { URL url, int i -> logger.info("    {} classpath url[{}]={}", taskName, i, url.getFile()) }
+        logger.info("====== Task '{}' classLoader URLs[{}] - END ======", taskName, urls.size())
+    }
+
+}

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/AbstractJReleaserTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/AbstractJReleaserTask.groovy
@@ -28,9 +28,9 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.options.Option
 import org.jreleaser.engine.context.ContextCreator
 import org.jreleaser.gradle.plugin.JReleaserExtension
-import org.jreleaser.gradle.plugin.internal.JReleaserExtensionImpl
 import org.jreleaser.gradle.plugin.internal.JReleaserLoggerService
 import org.jreleaser.gradle.plugin.internal.JReleaserProjectConfigurer
+import org.jreleaser.gradle.plugin.internal.JReleaserGradleProjectCapture
 import org.jreleaser.logging.JReleaserLogger
 import org.jreleaser.model.JReleaserVersion
 import org.jreleaser.model.api.JReleaserCommand
@@ -55,7 +55,7 @@ import static org.jreleaser.util.StringUtils.isNotBlank
  * @since 0.1.0
  */
 @CompileStatic
-abstract class AbstractJReleaserTask extends DefaultTask {
+abstract class AbstractJReleaserTask extends AbstractJReleaserDefaultTask {
     @Input
     final Property<Boolean> yolo
 
@@ -68,12 +68,6 @@ abstract class AbstractJReleaserTask extends DefaultTask {
     @Input
     final Property<Boolean> strict
 
-    @OutputDirectory
-    final DirectoryProperty outputDirectory
-
-    @Internal
-    final Property<JReleaserLoggerService> jlogger
-
     @Internal
     org.jreleaser.model.api.JReleaserContext.Mode mode
 
@@ -82,13 +76,12 @@ abstract class AbstractJReleaserTask extends DefaultTask {
 
     @Inject
     AbstractJReleaserTask(ObjectFactory objects) {
-        jlogger = objects.property(JReleaserLoggerService)
+        super(objects)
         mode = FULL
-        yolo = objects.property(Boolean)
-        dryrun = objects.property(Boolean)
-        gitRootSearch = objects.property(Boolean)
-        strict = objects.property(Boolean)
-        outputDirectory = objects.directoryProperty().convention(project.layout.buildDirectory.dir('jreleaser'))
+        yolo = objects.property(Boolean).convention(extension.get().yolo)
+        dryrun = objects.property(Boolean).convention(extension.get().dryrun)
+        gitRootSearch = objects.property(Boolean).convention(extension.get().gitRootSearch)
+        strict = objects.property(Boolean).convention(extension.get().strict)
     }
 
     @Option(option = 'yolo', description = 'Skip non-configured operations (OPTIONAL).')
@@ -112,14 +105,13 @@ abstract class AbstractJReleaserTask extends DefaultTask {
     }
 
     protected JReleaserModel createModel() {
-        JReleaserExtensionImpl extension = (JReleaserExtensionImpl) project.extensions.findByType(JReleaserExtension)
-        JReleaserModel model = extension.toModel(project, jlogger.get().logger)
-        JReleaserProjectConfigurer.configureModel(project, model)
+        JReleaserModel model = extension.get().toModel(gradleProjectCapture.get(), jlogger.get().logger)
+        JReleaserProjectConfigurer.configureModel(gradleProjectCapture.get(), model)
         model
     }
 
     private Path resolveSettings() {
-        JReleaserExtensionImpl extension = (JReleaserExtensionImpl) project.extensions.findByType(JReleaserExtension)
+        JReleaserExtension extension = this.extension.get()
         if (extension.getSettingsFile().present) {
             return extension.getSettingsFile().asFile.get().toPath()
         }
@@ -134,7 +126,7 @@ abstract class AbstractJReleaserTask extends DefaultTask {
         logger.info('JReleaser {}', JReleaserVersion.getPlainVersion())
         JReleaserVersion.banner(logger.getTracer())
         logger.increaseIndent()
-        logger.info('- basedir set to {}', project.projectDir.toPath().toAbsolutePath())
+        logger.info('- basedir set to {}', projectDirectory.get().asFile.toPath().toAbsolutePath())
         Path settings = resolveSettings()
         if (settings) {
             logger.info('- settings set to {}', settings.toAbsolutePath())
@@ -144,11 +136,11 @@ abstract class AbstractJReleaserTask extends DefaultTask {
 
         return ContextCreator.create(
             logger,
-            resolveConfigurer(project.extensions.findByType(JReleaserExtension)),
+            resolveConfigurer(extension.get()),
             mode,
             command,
             createModel(),
-            project.projectDir.toPath(),
+            projectDirectory.get().asFile.toPath(),
             settings,
             outputDirectory.get().asFile.toPath(),
             yolo.getOrElse(false),

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaseAutoConfigReleaseTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaseAutoConfigReleaseTask.groovy
@@ -51,11 +51,9 @@ import static org.jreleaser.util.StringUtils.isNotBlank
  * @since 0.3.0
  */
 @CompileStatic
-abstract class JReleaseAutoConfigReleaseTask extends DefaultTask {
+abstract class JReleaseAutoConfigReleaseTask extends AbstractJReleaserDefaultTask {
     static final String NAME = 'jreleaserAutoConfigRelease'
 
-    @OutputDirectory
-    final DirectoryProperty outputDirectory
     @Input
     @Optional
     final Property<Boolean> yolo
@@ -175,8 +173,6 @@ abstract class JReleaseAutoConfigReleaseTask extends DefaultTask {
     @Input
     @Optional
     final ListProperty<String> rejectPlatforms
-    @Internal
-    final Property<JReleaserLoggerService> jlogger
 
     @Option(option = 'project-name', description = 'The project name (OPTIONAL).')
     void setProjectName(String projectName) {
@@ -386,12 +382,11 @@ abstract class JReleaseAutoConfigReleaseTask extends DefaultTask {
 
     @Inject
     JReleaseAutoConfigReleaseTask(ObjectFactory objects) {
-        yolo = objects.property(Boolean)
-        dryrun = objects.property(Boolean)
-        gitRootSearch = objects.property(Boolean)
-        strict = objects.property(Boolean)
-        outputDirectory = objects.directoryProperty().convention(project.layout.buildDirectory.dir('jreleaser'))
-        jlogger = objects.property(JReleaserLoggerService)
+        super(objects)
+        yolo = objects.property(Boolean).convention(extension.get().yolo)
+        dryrun = objects.property(Boolean).convention(extension.get().dryrun)
+        gitRootSearch = objects.property(Boolean).convention(extension.get().gitRootSearch)
+        strict = objects.property(Boolean).convention(extension.get().strict)
 
         projectName = objects.property(String).convention(project.name)
         projectVersion = objects.property(String).convention(String.valueOf(project.version))
@@ -435,7 +430,7 @@ abstract class JReleaseAutoConfigReleaseTask extends DefaultTask {
     void performAction() {
         JReleaserContext context = ModelAutoConfigurer.builder()
             .logger(jlogger.get().logger)
-            .basedir(project.projectDir.toPath())
+            .basedir(projectDirectory.get().asFile.toPath())
             .outputDirectory(outputDirectory.get().asFile.toPath())
             .yolo(yolo.getOrElse(false))
             .dryrun(dryrun.getOrElse(false))

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserAnnounceTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserAnnounceTask.groovy
@@ -56,6 +56,7 @@ abstract class JReleaserAnnounceTask extends AbstractJReleaserTask {
         excludedAnnouncers = objects.listProperty(String).convention([])
         mode = ANNOUNCE
         command = JReleaserCommand.ANNOUNCE
+        dependOnAssembleDistIfDistributionPluginIsApplied()
     }
 
     @Option(option = 'announcer', description = 'Include an announcer (OPTIONAL).')

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserChecksumTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserChecksumTask.groovy
@@ -53,6 +53,7 @@ abstract class JReleaserChecksumTask extends AbstractPlatformAwareJReleaserTask 
         distributions = objects.listProperty(String).convention([])
         excludedDistributions = objects.listProperty(String).convention([])
         command = JReleaserCommand.CHECKSUM
+        dependOnAssembleDistIfDistributionPluginIsApplied()
     }
 
     @Option(option = 'distribution', description = 'Include a distribution (OPTIONAL).')

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserConfigTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserConfigTask.groovy
@@ -74,6 +74,7 @@ abstract class JReleaserConfigTask extends AbstractPlatformAwareJReleaserTask {
         deploy = objects.property(Boolean).convention(false)
         download = objects.property(Boolean).convention(false)
         command = JReleaserCommand.CONFIG
+        dependOnAssembleDistIfDistributionPluginIsApplied()
 
         // Disable up-to-date checks: jreleaser/issues/1972
         this.outputs.upToDateWhen { false }

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserEnvTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserEnvTask.groovy
@@ -18,18 +18,15 @@
 package org.jreleaser.gradle.plugin.tasks
 
 import groovy.transform.CompileStatic
-import org.gradle.api.DefaultTask
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
 import org.jreleaser.engine.environment.Environment
-import org.jreleaser.logging.JReleaserLogger
 
 import javax.inject.Inject
 
@@ -39,14 +36,11 @@ import javax.inject.Inject
  * @since 1.5.0
  */
 @CompileStatic
-abstract class JReleaserEnvTask extends DefaultTask {
+abstract class JReleaserEnvTask extends AbstractJReleaserDefaultTask {
     static final String NAME = 'jreleaserEnv'
 
     @Input
-    final Property<JReleaserLogger> jlogger
-
-    @InputDirectory
-    final DirectoryProperty basedir
+    final Property<Boolean> logClasspath
 
     @InputFile
     @Optional
@@ -54,17 +48,25 @@ abstract class JReleaserEnvTask extends DefaultTask {
 
     @Inject
     JReleaserEnvTask(ObjectFactory objects) {
-        jlogger = objects.property(JReleaserLogger)
-        basedir = objects.directoryProperty()
+        super(objects)
+        logClasspath = objects.property(Boolean).convention(false)
         settings = objects.fileProperty()
         
         // Disable up-to-date checks: jreleaser/issues/1972
         this.outputs.upToDateWhen { false }
     }
 
+    @Option(option = 'logClasspath', description = 'Log actual classpath at task execution time on info level (OPTIONAL).')
+    void setLogClasspath(boolean logClasspath) {
+        this.logClasspath.set(logClasspath)
+    }
+
     @TaskAction
     void performAction() {
-        Environment.display(jlogger.get(), basedir.get().asFile.toPath(),
+        if (logClasspath.getOrElse(false)) {
+            logClassLoaderURLs()
+        }
+        Environment.display(jlogger.get().logger, projectDirectory.get().asFile.toPath(),
             settings.present ? settings.get().asFile.toPath() : null)
     }
 }

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserFullReleaseTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserFullReleaseTask.groovy
@@ -103,6 +103,7 @@ abstract class JReleaserFullReleaseTask extends AbstractJReleaserPackagerTask {
         catalogers = objects.listProperty(String).convention([])
         excludedCatalogers = objects.listProperty(String).convention([])
         command = JReleaserCommand.FULL_RELEASE
+        dependOnAssembleDistIfDistributionPluginIsApplied()
     }
 
     @Option(option = 'deployer', description = 'Include a deployer by type (OPTIONAL).')

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserInitTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserInitTask.groovy
@@ -46,29 +46,21 @@ import static org.jreleaser.bundle.RB.$
  */
 @CompileStatic
 @UntrackedTask(because = 'writes to project.basedir')
-abstract class JReleaserInitTask extends DefaultTask {
+abstract class JReleaserInitTask extends AbstractJReleaserDefaultTask {
     static final String NAME = 'jreleaserInit'
 
     @Input
     @Optional
     final Property<String> format
 
-    @OutputDirectory
-    final DirectoryProperty outputDirectory
-
     @Input
     final Property<Boolean> overwrite
 
-    @Internal
-    final Property<JReleaserLoggerService> jlogger
-
     @Inject
     JReleaserInitTask(ObjectFactory objects) {
-        jlogger = objects.property(JReleaserLoggerService)
+        super(objects)
         format = objects.property(String).convention(Providers.<String> notDefined())
         overwrite = objects.property(Boolean).convention(false)
-
-        outputDirectory = objects.directoryProperty()
     }
 
     @Option(option = 'overwrite', description = 'Overwrite existing files (OPTIONAL).')

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserPackageTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserPackageTask.groovy
@@ -38,6 +38,7 @@ abstract class JReleaserPackageTask extends AbstractJReleaserPackagerTask {
     JReleaserPackageTask(ObjectFactory objects) {
         super(objects)
         command = JReleaserCommand.PACKAGE
+        dependOnAssembleDistIfDistributionPluginIsApplied()
     }
 
     @TaskAction

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserPrepareTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserPrepareTask.groovy
@@ -38,6 +38,7 @@ abstract class JReleaserPrepareTask extends AbstractJReleaserPackagerTask {
     JReleaserPrepareTask(ObjectFactory objects) {
         super(objects)
         command = JReleaserCommand.PREPARE
+        dependOnAssembleDistIfDistributionPluginIsApplied()
     }
 
     @TaskAction

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserPublishTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserPublishTask.groovy
@@ -38,6 +38,7 @@ abstract class JReleaserPublishTask extends AbstractJReleaserPackagerTask {
     JReleaserPublishTask(ObjectFactory objects) {
         super(objects)
         command = JReleaserCommand.PUBLISH
+        dependOnAssembleDistIfDistributionPluginIsApplied()
     }
 
     @TaskAction

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserReleaseTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserReleaseTask.groovy
@@ -93,6 +93,7 @@ abstract class JReleaserReleaseTask extends AbstractJReleaserDistributionTask {
         catalogers = objects.listProperty(String).convention([])
         excludedCatalogers = objects.listProperty(String).convention([])
         command = JReleaserCommand.RELEASE
+        dependOnAssembleDistIfDistributionPluginIsApplied()
     }
 
     @Option(option = 'deployer', description = 'Include a deployer by type (OPTIONAL).')

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserSignTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserSignTask.groovy
@@ -53,6 +53,7 @@ abstract class JReleaserSignTask extends AbstractPlatformAwareJReleaserTask {
         distributions = objects.listProperty(String).convention([])
         excludedDistributions = objects.listProperty(String).convention([])
         command = JReleaserCommand.SIGN
+        dependOnAssembleDistIfDistributionPluginIsApplied()
     }
 
     @Option(option = 'distribution', description = 'Include a distribution (OPTIONAL).')

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserTemplateGenerateTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserTemplateGenerateTask.groovy
@@ -44,7 +44,7 @@ import java.nio.file.Path
  * @since 0.1.0
  */
 @CompileStatic
-abstract class JReleaserTemplateGenerateTask extends DefaultTask {
+abstract class JReleaserTemplateGenerateTask extends AbstractJReleaserDefaultTask {
     static final String NAME = 'jreleaserTemplateGenerate'
 
     @Input
@@ -71,21 +71,15 @@ abstract class JReleaserTemplateGenerateTask extends DefaultTask {
     @Optional
     final Property<String> assemblerName
 
-    @OutputDirectory
-    final DirectoryProperty outputDirectory
-
     @Input
     final Property<Boolean> overwrite
 
     @Input
     final Property<Boolean> snapshot
 
-    @Internal
-    final Property<JReleaserLoggerService> jlogger
-
     @Inject
     JReleaserTemplateGenerateTask(ObjectFactory objects) {
-        jlogger = objects.property(JReleaserLoggerService)
+        super(objects)
         distributionType = objects.property(Distribution.DistributionType).convention(Distribution.DistributionType.JAVA_BINARY)
         distributionName = objects.property(String)
         packagerName = objects.property(String)
@@ -94,8 +88,6 @@ abstract class JReleaserTemplateGenerateTask extends DefaultTask {
         assemblerName = objects.property(String).convention(Providers.<String> notDefined())
         overwrite = objects.property(Boolean).convention(false)
         snapshot = objects.property(Boolean).convention(false)
-
-        outputDirectory = objects.directoryProperty()
     }
 
     @Option(option = 'overwrite', description = 'Overwrite existing files (OPTIONAL).')

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserUploadTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserUploadTask.groovy
@@ -73,6 +73,7 @@ abstract class JReleaserUploadTask extends AbstractJReleaserDistributionTask {
         catalogers = objects.listProperty(String).convention([])
         excludedCatalogers = objects.listProperty(String).convention([])
         command = JReleaserCommand.UPLOAD
+        dependOnAssembleDistIfDistributionPluginIsApplied()
     }
 
     @Option(option = 'uploader', description = 'Include an uploader by type (OPTIONAL).')


### PR DESCRIPTION
Fixes #1992

### Context
The Gradle Project instance object must not be accessed from task execution during Gradle build runtime phase.
This is violating Gradle configuration cache pre-requisites and it is currently raising a warning since this kind of access is deprecated and will run into an error with Gradle 10.

### Solution
* **Refactor**
  * Internal plugin architecture reworked to centralize Gradle project metadata capture and configuration, reducing direct Gradle API coupling.
  * Tasks now share a common base for consistent initialization, simplifying task configuration and logging.
  * Several task inputs/outputs were streamlined; environment task now always re-runs (up-to-date disabled) and environment display uses the task's project directory.
  * Adds a JReleaserGradleProjectCapture value object and refactors the plugin to use it instead of direct Gradle Project access; method signatures and task base classes were updated to accept/use the capture and centralize project property resolution.

### Recommendations to do
- Class `AbstractJReleaserTask` should be renamed to something like `AbstractJReleaserCommonOptionsTask` or `AbstractJReleaserCoreOptionsTask` since it is now inheriting from `AbstractJReleaserDefaultTask` as next in the tasks inheritance hierarchy.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
