### PR TITLE
fix(docker): use consistent paths in single-jar Dockerfile template

### DIFF
--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/single-jar/docker/Dockerfile.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/single-jar/docker/Dockerfile.tpl
@@ -5,8 +5,8 @@ FROM alpine:latest AS assembler
 
 COPY assembly/ /assembly/
 
-RUN mkdir -p /opt/{{distributionName}}-{{projectVersion}}/bin && \
-    mkdir -p /opt/{{distributionName}}-{{projectVersion}}/lib && \
+RUN mkdir -p /opt/{{distributionExecutableName}}/bin && \
+    mkdir -p /opt/{{distributionExecutableName}}/lib && \
     mv /assembly/{{distributionExecutableUnix}} /opt/{{distributionExecutableName}}/bin && \
     chmod +x /opt/{{distributionExecutableName}}/bin/{{distributionExecutableUnix}} && \
     mv /assembly/{{distributionArtifactFile}} /opt/{{distributionExecutableName}}/lib


### PR DESCRIPTION
## Summary

Fixes inconsistent paths in the single-jar Docker template that caused Docker build failures.

## Problem

The `mkdir` commands used `{{distributionName}}-{{projectVersion}}` while the `mv` and `COPY` commands used `{{distributionExecutableName}}`, resulting in path mismatches:

```
mkdir -p /opt/korvet-0.7.3-SNAPSHOT/bin &&
mkdir -p /opt/korvet-0.7.3-SNAPSHOT/lib &&
mv /assembly/korvet /opt/korvet/bin &&     # ERROR: directory doesn't exist!
```

## Solution

Changed `mkdir` commands to use `{{distributionExecutableName}}` consistently with the rest of the template.

## Testing

Verified the generated Dockerfile now has consistent paths throughout.
