### PR TITLE
feat(gradle): Rename AbstractJReleaserTask to AbstractJReleaserCommonOptionsTask

### DIFF
--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/AbstractJReleaserCommonOptionsTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/AbstractJReleaserCommonOptionsTask.groovy
@@ -18,19 +18,14 @@
 package org.jreleaser.gradle.plugin.tasks
 
 import groovy.transform.CompileStatic
-import org.gradle.api.DefaultTask
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.options.Option
 import org.jreleaser.engine.context.ContextCreator
 import org.jreleaser.gradle.plugin.JReleaserExtension
-import org.jreleaser.gradle.plugin.internal.JReleaserLoggerService
 import org.jreleaser.gradle.plugin.internal.JReleaserProjectConfigurer
-import org.jreleaser.gradle.plugin.internal.JReleaserGradleProjectCapture
 import org.jreleaser.logging.JReleaserLogger
 import org.jreleaser.model.JReleaserVersion
 import org.jreleaser.model.api.JReleaserCommand
@@ -55,7 +50,7 @@ import static org.jreleaser.util.StringUtils.isNotBlank
  * @since 0.1.0
  */
 @CompileStatic
-abstract class AbstractJReleaserTask extends AbstractJReleaserDefaultTask {
+abstract class AbstractJReleaserCommonOptionsTask extends AbstractJReleaserDefaultTask {
     @Input
     final Property<Boolean> yolo
 
@@ -75,7 +70,7 @@ abstract class AbstractJReleaserTask extends AbstractJReleaserDefaultTask {
     JReleaserCommand command
 
     @Inject
-    AbstractJReleaserTask(ObjectFactory objects) {
+    AbstractJReleaserCommonOptionsTask(ObjectFactory objects) {
         super(objects)
         mode = FULL
         yolo = objects.property(Boolean).convention(extension.get().yolo)

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/AbstractPlatformAwareJReleaserTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/AbstractPlatformAwareJReleaserTask.groovy
@@ -34,7 +34,7 @@ import javax.inject.Inject
  * @since 0.6.0
  */
 @CompileStatic
-abstract class AbstractPlatformAwareJReleaserTask extends AbstractJReleaserTask {
+abstract class AbstractPlatformAwareJReleaserTask extends AbstractJReleaserCommonOptionsTask {
     @Input
     @Optional
     final Property<Boolean> selectCurrentPlatform

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserAnnounceTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserAnnounceTask.groovy
@@ -38,7 +38,7 @@ import static org.jreleaser.model.api.JReleaserContext.Mode.ANNOUNCE
  * @since 0.1.0
  */
 @CompileStatic
-abstract class JReleaserAnnounceTask extends AbstractJReleaserTask {
+abstract class JReleaserAnnounceTask extends AbstractJReleaserCommonOptionsTask {
     static final String NAME = 'jreleaserAnnounce'
 
     @Input

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserChangelogTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserChangelogTask.groovy
@@ -33,7 +33,7 @@ import static org.jreleaser.model.api.JReleaserContext.Mode.CHANGELOG
  * @since 0.1.0
  */
 @CompileStatic
-abstract class JReleaserChangelogTask extends AbstractJReleaserTask {
+abstract class JReleaserChangelogTask extends AbstractJReleaserCommonOptionsTask {
     static final String NAME = 'jreleaserChangelog'
 
     @Inject

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserDeployTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserDeployTask.groovy
@@ -38,7 +38,7 @@ import static org.jreleaser.model.api.JReleaserContext.Mode.DEPLOY
  * @since 1.3.0
  */
 @CompileStatic
-abstract class JReleaserDeployTask extends AbstractJReleaserTask {
+abstract class JReleaserDeployTask extends AbstractJReleaserCommonOptionsTask {
     static final String NAME = 'jreleaserDeploy'
 
     @Input

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserDownloadTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserDownloadTask.groovy
@@ -38,7 +38,7 @@ import static org.jreleaser.model.api.JReleaserContext.Mode.DOWNLOAD
  * @since 1.1.0
  */
 @CompileStatic
-abstract class JReleaserDownloadTask extends AbstractJReleaserTask {
+abstract class JReleaserDownloadTask extends AbstractJReleaserCommonOptionsTask {
     static final String NAME = 'jreleaserDownload'
 
     @Input


### PR DESCRIPTION
<!-- The issue this PR addresses -->
<!-- Please reference the issue this PR solves -->
Following up an open to do recommendation of #2078

### Context
<!-- What problem does this change address? -->
<!-- Link to relevant issues or discussions here -->
This is a cosmetic change to reflect better what the former `AbstractJReleaserTask` class is being supposed for.
👉 This change is preserving the git history of the original source file.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
