### PR TITLE
fix(gradle): Add property keys related to deprecated Convention APIs

### DIFF
--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/JReleaserGradleProjectCapture.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/JReleaserGradleProjectCapture.groovy
@@ -43,6 +43,10 @@ class JReleaserGradleProjectCapture implements Serializable {
 
     // List of Gradle Project properties that are deprecated in Gradle 9
     // and should be ignored to avoid deprecation warnings.
+    // Refer to deprecated Convention APIs:
+    //   org.gradle.api.plugins.internal.NaggingJavaPluginConvention
+    //   org.gradle.api.plugins.BasePluginConvention
+    //   org.gradle.api.plugins.JavaPluginConvention
     private static final List<String> GRADLE_DEPRECATED_PROJECT_PROPS = [
         'archivesBaseName',
         'archivesName',
@@ -54,6 +58,12 @@ class JReleaserGradleProjectCapture implements Serializable {
         'docsDirName',
         'libsDirectory',
         'libsDirName',
+        'manifest',
+        'project',
+        'reportsDir',
+        'sourceSets',
+        'sourceCompatibility',
+        'targetCompatibility',
         'testReportDir',
         'testReportDirName',
         'testResultsDir',


### PR DESCRIPTION

<!-- The issue this PR addresses -->
<!-- Please reference the issue this PR solves -->
Followup to #2078

### Context
<!-- What problem does this change address? -->
<!-- Link to relevant issues or discussions here -->
Did recognize that there are a few property keys missing to ban from deprecated Convention API access.
Source of information are the classes referenced in the code comment added within `JReleaserGradleProjectCapture.groovy`.
- JReleaserGradleProjectCapture.groovy:
  - add property keys missing to ban from deprecated Convention API access
  - enhance code comment to list API classes referenced for this list


### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
