### PR TITLE
fix(core): Avoid duplicate resources in Native Image by using -cp option during assemble step

### DIFF
--- a/api/jreleaser-resource-bundle/src/main/resources/org/jreleaser/bundle/Messages.properties
+++ b/api/jreleaser-resource-bundle/src/main/resources/org/jreleaser/bundle/Messages.properties
@@ -340,6 +340,8 @@ ERROR_jpackage_runtime_image_not_found     = Could not find a runtime image matc
 ERROR_swid_generator                       = Unexpected error when generating SWID tag from {}
 ERROR_assemble_swid_tag                    = Unexpected error when generating SWID tag for {}
 assemble.deb.unsupported.artifact          = Deb assembler does not support artifact for {}
+ERROR_assembler_autodetect_main_class      = Could not find Main-Class attribute in the manifest of {}
+ERROR_assembler_no_main_class              = Could not resolve main class: value not configured in the DSL and no Main-Class attribute found in the manifest of {}
 
 ERROR_invalid_config_file       = Invalid config file. {}
 ERROR_parsing_config_file       = Unexpected error parsing config file. {}

--- a/core/jreleaser-engine/jreleaser-engine.gradle
+++ b/core/jreleaser-engine/jreleaser-engine.gradle
@@ -34,6 +34,9 @@ dependencies {
     compileOnly "org.kordamp.jipsy:jipsy-annotations:${jipsyVersion}"
     annotationProcessor "org.kordamp.jipsy:jipsy-processor:${jipsyVersion}"
 
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation "org.mockito:mockito-junit-jupiter:$mockitoVersion"
+
     // announce
     api project(':jreleaser-bluesky-java-sdk')
     api project(':jreleaser-discord-java-sdk')

--- a/core/jreleaser-engine/src/main/java/org/jreleaser/assemblers/NativeImageAssemblerProcessor.java
+++ b/core/jreleaser-engine/src/main/java/org/jreleaser/assemblers/NativeImageAssemblerProcessor.java
@@ -41,6 +41,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
 
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
@@ -49,6 +51,7 @@ import static org.jreleaser.assemblers.AssemblerUtils.readJavaVersion;
 import static org.jreleaser.model.Constants.KEY_ARCHIVE_FORMAT;
 import static org.jreleaser.mustache.Templates.resolveTemplate;
 import static org.jreleaser.util.FileType.EXE;
+import static org.jreleaser.util.StringUtils.isBlank;
 import static org.jreleaser.util.StringUtils.isNotBlank;
 
 /**
@@ -181,9 +184,6 @@ public class NativeImageAssemblerProcessor extends AbstractAssemblerProcessor<or
             .collect(toList()));
 
         if (isNotBlank(assembler.getJava().getMainModule())) {
-            cmd.arg("--module")
-                .arg(resolveTemplate(context.getLogger(), assembler.getJava().getMainModule(), props) + "/" + resolveTemplate(context.getLogger(), assembler.getJava().getMainClass(), props));
-
             cmd.arg("--module-path")
                 .arg(jars.stream()
                     .map(Path::toAbsolutePath)
@@ -194,21 +194,25 @@ public class NativeImageAssemblerProcessor extends AbstractAssemblerProcessor<or
                     .collect(joining(File.pathSeparator)));
 
         } else {
-            cmd.arg("-jar")
-                .arg(maybeQuote(assembler.getMainJar().getEffectivePath(context, assembler).toAbsolutePath().toString()));
-
-            if (!jars.isEmpty()) {
-                cmd.arg("-cp")
-                    .arg(jars.stream()
-                        .map(Path::toAbsolutePath)
-                        .map(image.getParent()::relativize)
-                        .map(Path::toString)
-                        .map(this::maybeQuote)
-                        .collect(joining(File.pathSeparator)));
-            }
+            cmd.arg("-cp")
+                .arg(jars.stream()
+                    .map(Path::toAbsolutePath)
+                    .map(image.getParent()::relativize)
+                    .map(Path::toString)
+                    .map(this::maybeQuote)
+                    .collect(joining(File.pathSeparator)));
         }
 
         cmd.arg("-H:Name=" + executable);
+        String mainClass = isNotBlank(assembler.getJava().getMainClass()) ? assembler.getJava().getMainClass() : tryAutoDetectMainClass();
+        if (isBlank(mainClass)) {
+            throw new AssemblerProcessingException(RB.$("ERROR_assembler_no_main_class", assembler.getMainJar().getResolvedPath()));
+        } else if (isNotBlank(assembler.getJava().getMainModule())) {
+            cmd.arg("--module")
+                .arg(resolveTemplate(context.getLogger(), assembler.getJava().getMainModule(), props) + "/" + resolveTemplate(context.getLogger(), mainClass, props));
+        } else {
+            cmd.arg(resolveTemplate(context.getLogger(), mainClass, props));
+        }
         context.getLogger().debug(String.join(" ", cmd.getArgs()));
         executeCommand(image.getParent(), cmd);
 
@@ -245,6 +249,15 @@ public class NativeImageAssemblerProcessor extends AbstractAssemblerProcessor<or
             context.getLogger().debug("- {}", imageArchive.getFileName());
         } catch (IOException e) {
             throw new AssemblerProcessingException(RB.$("ERROR_unexpected_error"), e);
+        }
+    }
+
+    private String tryAutoDetectMainClass() {
+        try (JarFile mainJar = new JarFile(assembler.getMainJar().getEffectivePath(context, assembler).toString())) {
+            return mainJar.getManifest().getMainAttributes().getValue(Attributes.Name.MAIN_CLASS);
+        } catch (Exception e) {
+            context.getLogger().debug(RB.$("ERROR_assembler_autodetect_main_class", assembler.getMainJar().getResolvedPath()), e);
+            return "";
         }
     }
 

--- a/core/jreleaser-engine/src/test/java/org/jreleaser/assemblers/NativeImageAssemblerProcessorTest.java
+++ b/core/jreleaser-engine/src/test/java/org/jreleaser/assemblers/NativeImageAssemblerProcessorTest.java
@@ -1,0 +1,383 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2026 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.assemblers;
+
+import org.jreleaser.logging.JReleaserLogger;
+import org.jreleaser.model.Constants;
+import org.jreleaser.model.internal.JReleaserContext;
+import org.jreleaser.model.internal.JReleaserModel;
+import org.jreleaser.model.internal.assemble.Assembler;
+import org.jreleaser.model.internal.assemble.NativeImageAssembler;
+import org.jreleaser.model.internal.common.Artifact;
+import org.jreleaser.model.internal.common.Glob;
+import org.jreleaser.model.internal.common.Java;
+import org.jreleaser.model.internal.platform.Platform;
+import org.jreleaser.model.internal.project.Project;
+import org.jreleaser.model.internal.release.BaseReleaser;
+import org.jreleaser.model.internal.release.Release;
+import org.jreleaser.model.spi.assemble.AssemblerProcessingException;
+import org.jreleaser.mustache.TemplateContext;
+import org.jreleaser.sdk.command.Command;
+import org.jreleaser.util.PlatformUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link NativeImageAssemblerProcessor}
+ */
+class NativeImageAssemblerProcessorTest {
+
+    private static final String DETECTED_OS_ARCH = PlatformUtils.getDetectedOs() + "-" + PlatformUtils.getDetectedArch();
+
+    private static final String IMAGE_NAME = "jreleaser-1.24.0";
+
+    private static final String MAIN_CLASS = "org.jreleaser.cli.Main";
+
+    private static final String ERROR_ASSEMBLER_NO_MAIN_CLASS = "Could not resolve main class: value not configured in the DSL and no Main-Class attribute found in the manifest of %s";
+
+    private static final Path JARS_UNIVERSAL_DIR = Path.of("jars/universal");
+
+    enum Mode {
+        DEFAULT, AUTO_DETECT_MAIN_CLASS, AUTO_DETECT_MISSING_MAIN_CLASS, MODULAR_JAR, MODULAR_JAR_WITH_DEPS,
+        MODULAR_JAR_AUTO_DETECT_MAIN_CLASS, MODULAR_JAR_AUTO_DETECT_MISSING_MAIN_CLASS
+    }
+
+    @TempDir
+    Path tempDir;
+
+    Path graalVmJdkDir;
+
+    Path nativeImageFile;
+
+    TemplateContext props;
+
+    NativeImageAssembler assembler;
+
+    NativeImageAssemblerProcessor nativeImageAssemblerProcessor;
+
+    @BeforeEach
+    void setup() throws Exception {
+        setupTestData();
+        setupMocks();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Mode.class, names = {"DEFAULT", "AUTO_DETECT_MAIN_CLASS", "AUTO_DETECT_MISSING_MAIN_CLASS"})
+    void testAssembleBinary_UberJar(Mode mode) throws Exception {
+        Artifact mainJar = mockMainJar(mode);
+        when(assembler.getMainJar()).thenReturn(mainJar);
+        if (mode.name().startsWith("AUTO_DETECT")) {
+            Java java = mock(Java.class);
+            when(assembler.getJava()).thenReturn(java);
+        }
+
+        Command expectedCommand = new Command(nativeImageFile.toString(), true);
+        expectedCommand.arg("-cp")
+            .arg(JARS_UNIVERSAL_DIR.resolve(IMAGE_NAME + ".jar").toString())
+            .arg("-H:Name=" + IMAGE_NAME + "-" + DETECTED_OS_ARCH)
+            .arg(MAIN_CLASS);
+        Throwable exception = catchThrowable(() -> testAssembleBinary(expectedCommand));
+        if (Mode.AUTO_DETECT_MISSING_MAIN_CLASS.equals(mode)) {
+            assertThat(exception)
+                .isInstanceOf(AssemblerProcessingException.class)
+                .hasMessageContaining(ERROR_ASSEMBLER_NO_MAIN_CLASS.formatted(tempDir.resolve(IMAGE_NAME + ".jar")));
+        } else {
+            assertThat(exception).isNull();
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Mode.class, names = {"DEFAULT", "AUTO_DETECT_MAIN_CLASS", "AUTO_DETECT_MISSING_MAIN_CLASS"})
+    void testAssembleBinary_JarWithDependencies(Mode mode) throws Exception {
+        Artifact mainJar = mockMainJar(mode);
+        List<Glob> jars = mockJars();
+        when(assembler.getMainJar()).thenReturn(mainJar);
+        when(assembler.getJars()).thenReturn(jars);
+        if (mode.name().startsWith("AUTO_DETECT")) {
+            Java java = mock(Java.class);
+            when(assembler.getJava()).thenReturn(java);
+        }
+
+        List<Path> classpath = List.of(JARS_UNIVERSAL_DIR.resolve(IMAGE_NAME + ".jar"),
+            JARS_UNIVERSAL_DIR.resolve("dependency1-1.0.0.jar"),
+            JARS_UNIVERSAL_DIR.resolve("dependency2-2.0.0.jar"),
+            JARS_UNIVERSAL_DIR.resolve("dependency3-3.0.0.jar"));
+        Command expectedCommand = new Command(nativeImageFile.toString(), true);
+        expectedCommand.arg("-cp")
+            .arg(classpath.stream().map(Path::toString).collect(Collectors.joining(File.pathSeparator)))
+            .arg("-H:Name=" + IMAGE_NAME + "-" + DETECTED_OS_ARCH)
+            .arg(MAIN_CLASS);
+        Throwable exception = catchThrowable(() -> testAssembleBinary(expectedCommand));
+        if (Mode.AUTO_DETECT_MISSING_MAIN_CLASS.equals(mode)) {
+            assertThat(exception)
+                .isInstanceOf(AssemblerProcessingException.class)
+                .hasMessageContaining(ERROR_ASSEMBLER_NO_MAIN_CLASS.formatted(tempDir.resolve(IMAGE_NAME + ".jar")));
+        } else {
+            assertThat(exception).isNull();
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Mode.class, names = {"MODULAR_JAR", "MODULAR_JAR_WITH_DEPS", "MODULAR_JAR_AUTO_DETECT_MAIN_CLASS",
+        "MODULAR_JAR_AUTO_DETECT_MISSING_MAIN_CLASS"})
+    void testAssembleBinary_ModularJar(Mode mode) throws Exception {
+        Artifact mainJar = mockMainJar(mode);
+        String mainModule = MAIN_CLASS.substring(0, MAIN_CLASS.lastIndexOf('.'));
+        when(assembler.getMainJar()).thenReturn(mainJar);
+        when(assembler.getJava().getMainModule()).thenReturn(mainModule);
+        if (Mode.MODULAR_JAR_WITH_DEPS.equals(mode)) {
+            List<Glob> jars = mockJars(mode);
+            when(assembler.getJars()).thenReturn(jars);
+        } else if (mode.name().contains("AUTO_DETECT")) {
+            when(assembler.getJava().getMainClass()).thenReturn("");
+        }
+
+        Path distributionAssembleDir = props.get(Constants.KEY_DISTRIBUTION_ASSEMBLE_DIRECTORY);
+        Command expectedCommand = new Command(nativeImageFile.toString(), true);
+        expectedCommand.arg("--module-path")
+            .arg(distributionAssembleDir.resolve(JARS_UNIVERSAL_DIR).toString())
+            .arg("-H:Name=" + IMAGE_NAME + "-" + DETECTED_OS_ARCH)
+            .arg("--module")
+            .arg(mainModule + "/" + MAIN_CLASS);
+        Throwable exception = catchThrowable(() -> testAssembleBinary(expectedCommand));
+        if (Mode.MODULAR_JAR_AUTO_DETECT_MISSING_MAIN_CLASS.equals(mode)) {
+            assertThat(exception)
+                .isInstanceOf(AssemblerProcessingException.class)
+                .hasMessageContaining(ERROR_ASSEMBLER_NO_MAIN_CLASS.formatted(tempDir.resolve(IMAGE_NAME + ".jar")));
+        } else {
+            assertThat(exception).isNull();
+        }
+    }
+
+    private void testAssembleBinary(Command expectedCommand) throws Exception {
+        nativeImageAssemblerProcessor.assemble(props);
+
+        ArgumentCaptor<Command> commandCaptor = ArgumentCaptor.forClass(Command.class);
+        verify(nativeImageAssemblerProcessor).executeCommand(eq(props.get(Constants.KEY_DISTRIBUTION_ASSEMBLE_DIRECTORY)),
+            commandCaptor.capture());
+        Command actualCommand = commandCaptor.getValue();
+        assertThat(actualCommand).isNotNull();
+        assertCommandArgs(actualCommand.getArgs(), expectedCommand.getArgs());
+    }
+
+    private void assertCommandArgs(List<String> actualCommandArgs, List<String> expectedCommandArgs) {
+        int cpIndex = expectedCommandArgs.indexOf("-cp");
+        if (cpIndex < 0) {
+            assertThat(actualCommandArgs).isEqualTo(expectedCommandArgs);
+            return;
+        }
+        assertThat(actualCommandArgs).hasSameSizeAs(expectedCommandArgs);
+        int cpJarsIndex = cpIndex + 1;
+        assertThat(actualCommandArgs.subList(0, cpJarsIndex)).isEqualTo(expectedCommandArgs.subList(0, cpJarsIndex));
+        assertClasspath(actualCommandArgs.get(cpJarsIndex), expectedCommandArgs.get(cpJarsIndex));
+        if (expectedCommandArgs.size() > cpJarsIndex + 1) {
+            assertThat(actualCommandArgs.subList(cpJarsIndex + 1, actualCommandArgs.size()))
+                .isEqualTo(expectedCommandArgs.subList(cpJarsIndex + 1, expectedCommandArgs.size()));
+        }
+    }
+
+    private void assertClasspath(String actualClasspath, String expectedClasspath) {
+        List<String> actualJarsOnClasspath = Arrays.asList(actualClasspath.split(File.pathSeparator));
+        List<String> expectedJarsOnClasspath = Arrays.asList(expectedClasspath.split(File.pathSeparator));
+
+        assertThat(actualJarsOnClasspath).isNotEmpty();
+        assertThat(expectedJarsOnClasspath).isNotEmpty();
+        assertThat(actualJarsOnClasspath).hasSameSizeAs(expectedJarsOnClasspath);
+        assertThat(actualJarsOnClasspath.get(0)).isEqualTo(expectedJarsOnClasspath.get(0));
+        if (expectedJarsOnClasspath.size() > 1) {
+            assertThat(actualJarsOnClasspath.subList(1, actualJarsOnClasspath.size()))
+                .containsExactlyInAnyOrderElementsOf(expectedJarsOnClasspath.subList(1, expectedJarsOnClasspath.size()));
+        }
+    }
+
+    private Artifact mockMainJar(Mode mode) throws Exception {
+        Artifact mainJar = mock(Artifact.class);
+
+        Path mainJarFile = tempDir.resolve(IMAGE_NAME + ".jar");
+        createDummyJar(mainJarFile, mode);
+
+        when(mainJar.getPath()).thenReturn(mainJarFile.toString());
+        when(mainJar.getResolvedPath()).thenReturn(mainJarFile);
+        when(mainJar.getEffectivePath(any(JReleaserContext.class), any(Assembler.class))).thenReturn(mainJarFile);
+
+        return mainJar;
+    }
+
+    private List<Glob> mockJars() throws Exception {
+        return mockJars(Mode.DEFAULT);
+    }
+
+    private List<Glob> mockJars(Mode mode) throws Exception {
+        Glob glob = new Glob();
+
+        Path thirdPartyLibDir = tempDir.resolve("third-party/lib");
+        Files.createDirectories(thirdPartyLibDir);
+        glob.setPattern(thirdPartyLibDir + "/*.jar");
+        Path dependency1JarFile = thirdPartyLibDir.resolve("dependency1-1.0.0.jar");
+        Path dependency2JarFile = thirdPartyLibDir.resolve("dependency2-2.0.0.jar");
+        Path dependency3JarFile = thirdPartyLibDir.resolve("dependency3-3.0.0.jar");
+        createDummyJar(dependency1JarFile, mode);
+        createDummyJar(dependency2JarFile, mode);
+        createDummyJar(dependency3JarFile, mode);
+
+        return List.of(glob);
+    }
+
+    private void createDummyJar(Path jarFile, Mode mode) throws Exception {
+        String jarFileName = jarFile.getFileName().toString();
+        String jarPackage = jarFileName.substring(0, jarFileName.lastIndexOf('-'));
+        String imagePackage = IMAGE_NAME.substring(0, IMAGE_NAME.lastIndexOf('-'));
+        if (imagePackage.equals(jarPackage)) {
+            jarPackage += "/cli";
+        }
+
+        Manifest manifest = new Manifest();
+        manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        if (!mode.name().endsWith("AUTO_DETECT_MISSING_MAIN_CLASS")) {
+            manifest.getMainAttributes().put(Attributes.Name.MAIN_CLASS, MAIN_CLASS);
+        }
+
+        try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jarFile), manifest)) {
+            JarEntry mainClassEntry = new JarEntry("org/" + jarPackage + "/Main.class");
+            jos.putNextEntry(mainClassEntry);
+            jos.closeEntry();
+            if (mode.name().startsWith("MODULAR_JAR")) {
+                JarEntry moduleEntry = new JarEntry("module-info.class");
+                jos.putNextEntry(moduleEntry);
+                jos.closeEntry();
+            }
+        }
+
+        assertThat(jarFile).exists();
+    }
+
+    private void setupTestData() throws Exception {
+        graalVmJdkDir = tempDir.resolve("graalvm-jdk");
+        Path graalVmJdkBinDir = graalVmJdkDir.resolve("bin");
+        Files.createDirectories(graalVmJdkBinDir);
+        Path graalVmJdkReleaseFile = graalVmJdkDir.resolve("release");
+        Files.writeString(graalVmJdkReleaseFile, "JAVA_VERSION=\"21.0.10\"\nGRAALVM_VERSION=\"21.0.10\"");
+        String nativeImageFileName = PlatformUtils.isWindows() ? "native-image.cmd" : "native-image";
+        nativeImageFile = graalVmJdkBinDir.resolve(nativeImageFileName);
+        Files.createFile(nativeImageFile);
+    }
+
+    private void setupMocks() throws Exception {
+        props = TemplateContext.from(Map.of(
+            Constants.KEY_DISTRIBUTION_ASSEMBLE_DIRECTORY, tempDir.resolve("jreleaser/assemble/jreleaser-native/native-image"))
+        );
+        nativeImageAssemblerProcessor = spy(new NativeImageAssemblerProcessor(mockContext()));
+        mockExecuteCommand();
+        mockAssembler();
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private JReleaserContext mockContext() {
+        JReleaserContext context = mock(JReleaserContext.class);
+        JReleaserLogger logger = mock(JReleaserLogger.class);
+        JReleaserModel model = mock(JReleaserModel.class);
+        Project project = mock(Project.class);
+        Release release = mock(Release.class);
+        BaseReleaser releaser = mock(BaseReleaser.class);
+
+        when(context.getLogger()).thenReturn(logger);
+        when(context.getModel()).thenReturn(model);
+        when(model.getProject()).thenReturn(project);
+        when(model.getRelease()).thenReturn(release);
+        when(release.getReleaser()).thenReturn(releaser);
+        when(context.getBasedir()).thenReturn(tempDir);
+        when(context.fullProps()).thenReturn(props);
+        when(context.isPlatformSelected(nullable(String.class))).thenReturn(true);
+
+        return context;
+    }
+
+    private void mockExecuteCommand() throws Exception {
+        Command.Result commandResult = mock(Command.Result.class);
+        when(commandResult.getExitValue()).thenReturn(0);
+        doReturn(commandResult)
+            .when(nativeImageAssemblerProcessor)
+            .executeCommand(any(Path.class), any(Command.class));
+    }
+
+    private void mockAssembler() {
+        assembler = mock(NativeImageAssembler.class);
+        Artifact graal = mockGraal();
+        Platform platform = new Platform();
+        NativeImageAssembler.Archiving archiving = mock(NativeImageAssembler.Archiving.class);
+        NativeImageAssembler.PlatformCustomizer platformCustomizer = mock(NativeImageAssembler.PlatformCustomizer.class);
+        Java java = mockJava();
+        NativeImageAssembler.Upx upx = mock(NativeImageAssembler.Upx.class);
+
+        when(assembler.getGraal()).thenReturn(graal);
+        when(assembler.getPlatform()).thenReturn(platform);
+        when(assembler.getArchiving()).thenReturn(archiving);
+        when(assembler.getResolvedPlatformCustomizer()).thenReturn(platformCustomizer);
+        when(assembler.getJava()).thenReturn(java);
+        when(assembler.getUpx()).thenReturn(upx);
+        when(assembler.getResolvedImageName(any(JReleaserContext.class))).thenReturn(IMAGE_NAME);
+        when(assembler.getExecutable()).thenReturn(IMAGE_NAME);
+
+        nativeImageAssemblerProcessor.setAssembler(assembler);
+    }
+
+    private Artifact mockGraal() {
+        Artifact graal = mock(Artifact.class);
+
+        when(graal.isActiveAndSelected()).thenReturn(true);
+        when(graal.getEffectivePath(any(JReleaserContext.class), any(Assembler.class))).thenReturn(graalVmJdkDir);
+        when(graal.getPlatform()).thenReturn(DETECTED_OS_ARCH);
+
+        return graal;
+    }
+
+    private Java mockJava() {
+        Java java = mock(Java.class);
+
+        when(java.getMainClass()).thenReturn(MAIN_CLASS);
+
+        return java;
+    }
+
+}


### PR DESCRIPTION
Fixes #2094

### Context

Before the changes in this PR, JReleaser was using both: `-jar` and `-cp` options during Native Image assemble step.
Using both options results in duplicate resources in Native Image as shown in #2094.

The official [Native Maven Plugin](https://graalvm.github.io/native-build-tools/latest/maven-plugin.html) is using `-cp` option without `-jar` option and with main class at the end of the command.

The proposed solution is using `-cp` option with main class at the end of the command.
In `native-image` command when `-cp` option is used, main class at the end of the command is mandatory.
If user does not specify main class in `jreleaser.yml` (optional):
- In case of `-cp`: try to autodetect main class in Main Jar Manifest
- In case of `-jar`: `native-image` command autodetects main class in Main Jar Manifest

Changes were tested on real setup. Attaching the logs for Uber JAR case:
[trace-uber-jar-fix.log](https://github.com/user-attachments/files/26169625/trace-uber-jar-fix.log)

[Build Report](https://github.com/jdheim/toolfetch/blob/demo/uber-jar/toolfetch-0.0.1-linux-amd64-build-report-uber-jar-fix.html) indicates no duplicate resources:
<img width="1850" height="244" alt="uber-jar-fix" src="https://github.com/user-attachments/assets/b5a41c13-d978-496b-a0d2-269fdd4ef8ae" />

Attaching the logs for JAR with dependencies case:
[trace-jar-with-deps-fix.log](https://github.com/user-attachments/files/26169656/trace-jar-with-deps-fix.log)

[Build Report](https://github.com/jdheim/toolfetch/blob/demo/jar-with-deps/toolfetch-0.0.1-linux-amd64-build-report-jar-with-deps-fix.html) indicates no duplicate resources:
<img width="1859" height="261" alt="jar-with-deps-fix" src="https://github.com/user-attachments/assets/850e0e6f-3fbf-4430-b693-9a84cbcc7407" />

The changes were also covered with JUnit Tests.

### Examples

#### UberJAR

Before this PR the command looked like:

```shell
$ /tmp/junit-6453018531140388171/graalvm-jdk/bin/native-image \
    -jar \
    /tmp/junit-6453018531140388171/jreleaser-1.24.0.jar \
    -cp \
    jars/universal/jreleaser-1.24.0.jar \
    -H:Name=jreleaser-1.24.0-linux-amd64
```

After the changes in this PR the command looks like:

```shell
$ /tmp/junit-6453018531140388171/graalvm-jdk/bin/native-image \
    -cp \
    jars/universal/jreleaser-1.24.0.jar \
    -H:Name=jreleaser-1.24.0-linux-amd64 \
    org.jreleaser.cli.Main
```

#### JAR with dependencies

Before this PR the command looked like:

```shell
$ /tmp/junit-1579422173321533875/graalvm-jdk/bin/native-image \
    -jar \
    /tmp/junit-1579422173321533875/jreleaser-1.24.0.jar \
    -cp \
    jars/universal/jreleaser-1.24.0.jar:jars/universal/dependency1-1.0.0.jar:jars/universal/dependency2-2.0.0.jar:jars/universal/dependency3-3.0.0.jar \
    -H:Name=jreleaser-1.24.0-linux-amd64
```

After the changes in this PR the command looks like:

```shell
$ /tmp/junit-1579422173321533875/graalvm-jdk/bin/native-image \
    -cp \
    jars/universal/jreleaser-1.24.0.jar:jars/universal/dependency1-1.0.0.jar:jars/universal/dependency2-2.0.0.jar:jars/universal/dependency3-3.0.0.jar \
    -H:Name=jreleaser-1.24.0-linux-amd64 \
    org.jreleaser.cli.Main
```

### Modular App

No regressions when testing modular app:

<img width="1850" height="245" alt="image" src="https://github.com/user-attachments/assets/6484bb42-68d5-4d8c-ad10-4077e1fc287f" />

<img width="450" height="52" alt="image" src="https://github.com/user-attachments/assets/32ff9bc3-4f67-4399-9717-55fd2cc107c3" />

[trace.log](https://github.com/user-attachments/files/26227633/trace.log)

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
