### PR TITLE
fix(assemble): resolve relative launcher symlinks correctly

### DIFF
--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/java-archive/java-archive/bin/launcher.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/java-archive/java-archive/bin/launcher.tpl
@@ -12,6 +12,11 @@
 # Resolve links: $0 may be a link
 app_path=$0
 
+case $app_path in
+  */*) ;;
+  *) app_path=$(command -v -- "$app_path" 2>/dev/null || printf '%s' "$app_path") ;;
+esac
+
 # Need this for daisy-chained symlinks.
 while
     APP_HOME=${app_path%"${app_path##*/}"}  # leaves a trailing /; empty if no leading path


### PR DESCRIPTION
Closes #1994

## Summary
- resolve launcher names without a path component via `command -v` before the existing symlink resolution loop
- keep the existing APP_HOME resolution logic intact once the real script path is known

## Testing
- manual QA: generated a launcher from the updated template, created a relative symlink in a `bin/` directory, and executed it from PATH; `APP_HOME` resolved to the application directory instead of the wrong parent path