### PR TITLE
fix(packager): use snap arch in JAVA_HOME

### DIFF
--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/java-binary/snap/snap/snapcraft.yaml.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/java-binary/snap/snap/snapcraft.yaml.tpl
@@ -21,7 +21,7 @@ apps:
   {{distributionExecutableName}}:
     command: bin/{{distributionExecutableUnix}}
     environment:
-      JAVA_HOME: "$SNAP/usr/lib/jvm/java"
+      JAVA_HOME: "$SNAP/usr/lib/jvm/java-{{distributionJavaVersion}}-openjdk-${SNAP_ARCH}"
       PATH: "$SNAP/bin:$PATH:$JAVA_HOME/bin"
     {{#snapHasLocalPlugs}}
     plugs:

--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/single-jar/snap/snap/snapcraft.yaml.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/single-jar/snap/snap/snapcraft.yaml.tpl
@@ -26,7 +26,7 @@ apps:
     command: ${JAVA_HOME}/bin/java -jar $SNAP/{{distributionArtifactFile}}
     {{/distributionJavaMainModule}}
     environment:
-      JAVA_HOME: "$SNAP/usr/lib/jvm/java"
+      JAVA_HOME: "$SNAP/usr/lib/jvm/java-{{distributionJavaVersion}}-openjdk-${SNAP_ARCH}"
       PATH: "$PATH:$JAVA_HOME/bin"
     {{#snapHasLocalPlugs}}
     plugs:


### PR DESCRIPTION
Closes #2027

## Summary
- update the Java snap templates to point `JAVA_HOME` at the actual OpenJDK directory that includes the architecture suffix
- use `${SNAP_ARCH}` so the generated snap manifest resolves correctly on supported snap architectures instead of relying on `/usr/lib/jvm/java`

## Testing
- verified both Java snap templates now render `JAVA_HOME` as `$SNAP/usr/lib/jvm/java-{{distributionJavaVersion}}-openjdk-${SNAP_ARCH}`
- confirmed a rendered Java 8 example produces the expected runtime path shape: `/snap/jreleaser/73/usr/lib/jvm/java-8-openjdk-amd64`