### PR TITLE
fix(packagers): correct single-jar docker entrypoint

### DIFF
--- a/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/single-jar/docker/Dockerfile.tpl
+++ b/core/jreleaser-templates/src/main/resources/META-INF/jreleaser/templates/single-jar/docker/Dockerfile.tpl
@@ -30,7 +30,7 @@ ENV PATH="${PATH}:/{{distributionExecutableName}}/bin"
 {{.}}
 {{/dockerPostCommands}}
 
-ENTRYPOINT ["/{{dockerEntrypoint}}"]
+ENTRYPOINT {{dockerEntrypoint}}
 {{#dockerCmd}}
 CMD {{dockerCmd}}
 {{/dockerCmd}}

--- a/core/jreleaser-templates/src/test/java/org/jreleaser/templates/SingleJarDockerTemplateTest.java
+++ b/core/jreleaser-templates/src/test/java/org/jreleaser/templates/SingleJarDockerTemplateTest.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2026 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.templates;
+
+import org.jreleaser.util.IoUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class SingleJarDockerTemplateTest {
+    @Test
+    void should_render_single_jar_entrypoint_without_extra_wrapper() throws IOException {
+        try (InputStream in = getClass().getResourceAsStream("/META-INF/jreleaser/templates/single-jar/docker/Dockerfile.tpl")) {
+            String template = IoUtils.toString(in);
+
+            assertThat(template, containsString("ENTRYPOINT {{dockerEntrypoint}}"));
+            assertThat(template, not(containsString("ENTRYPOINT [\"/{{dockerEntrypoint}}\"]")));
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`single-jar`'s local Docker template wraps `dockerEntrypoint` in an extra exec-form array and leading slash:

```dockerfile
ENTRYPOINT ["/{{dockerEntrypoint}}"]
```

After `c775aa9f7` introduced type-specific Docker default entrypoints, `dockerEntrypoint` for `SINGLE_JAR` is already a full Docker exec-form JSON array:

```java
["/{{distributionExecutableName}}/bin/{{distributionExecutableUnix}}"]
```

That causes generated Dockerfiles like:

```dockerfile
ENTRYPOINT ["/["/korvet/bin/korvet""]
```

and explicit entrypoint overrides break in the same way.

## Reproduction

Using `jreleaser/jreleaser-slim:early-access` (`1.24.0-SNAPSHOT`) with a `SINGLE_JAR` distribution, the generated Dockerfile contains an invalid entrypoint. The same project with `jreleaser/jreleaser-slim:latest` (`1.23.0`) produces a valid launcher-script entrypoint.

I hit this while packaging `redisfield/korvet:early-access`:
- stable output generated a valid entrypoint
- early-access generated a broken one and the published image exited immediately at startup

## Cause

Template history shows the regression was introduced in `c775aa9f7` (`refactor(packagers): Fine tune multi-stage docker files`).

Before that change, `single-jar` hardcoded the launcher path directly:

```dockerfile
ENTRYPOINT ["/{{distributionName}}-{{projectVersion}}/bin/{{distributionExecutableUnix}}"]
```

After that change it switched to `dockerEntrypoint`, but unlike the other Docker templates it added an extra wrapper:

```dockerfile
ENTRYPOINT ["/{{dockerEntrypoint}}"]
```

## Solution

Render `dockerEntrypoint` verbatim in the `single-jar` Docker template, matching the other Docker packagers:

```dockerfile
ENTRYPOINT {{dockerEntrypoint}}
```

## Notes

I also added a narrow regression test in `core/jreleaser-templates` to guard against reintroducing the extra wrapper.

I was not able to get a clean local Gradle test run in this workspace because of local build-environment issues unrelated to the template change:
- the checked-in wrapper bootstrap here is incomplete in this clone
- the repo build then required Gradle 8.14.3 + Java 21
- after that, the build failed in a listener with `No HEAD exists and no explicit starting revision was specified`

The template change itself is intentionally minimal.
