### PR TITLE
fix(packagers): correct java-binary docker entrypoint

### DIFF
--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/packagers/DockerPackagerValidator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/packagers/DockerPackagerValidator.java
@@ -78,7 +78,7 @@ public final class DockerPackagerValidator {
         DEFAULT_ENTRYPOINTS.put(org.jreleaser.model.Distribution.DistributionType.FLAT_BINARY,
             "/{{distributionExecutableName}}");
         DEFAULT_ENTRYPOINTS.put(org.jreleaser.model.Distribution.DistributionType.JAVA_BINARY,
-            "[\"/{{distributionExecutableName}}/bin/{{distributionExecutableUnix}}\"");
+            "[\"/{{distributionExecutableName}}/bin/{{distributionExecutableUnix}}\"]");
         DEFAULT_ENTRYPOINTS.put(org.jreleaser.model.Distribution.DistributionType.JLINK,
             "[\"/{{distributionExecutableName}}/bin/{{distributionExecutableUnix}}\"");
         DEFAULT_ENTRYPOINTS.put(org.jreleaser.model.Distribution.DistributionType.NATIVE_IMAGE,


### PR DESCRIPTION
## Problem

`JAVA_BINARY`'s default Docker entrypoint in `DockerPackagerValidator` is missing the closing `]`.

```java
DEFAULT_ENTRYPOINTS.put(... JAVA_BINARY,
    "[\"/{{distributionExecutableName}}/bin/{{distributionExecutableUnix}}\"");
```

That renders generated Dockerfiles like:

```dockerfile
ENTRYPOINT ["/korvet/bin/korvet"
```

which Docker turns into a broken shell-form entrypoint at image build time.

## Reproduction

I reproduced this locally with `jreleaser/jreleaser-alpine:early-access` (`1.24.0-SNAPSHOT`) using a `JAVA_BINARY` Docker distribution. The generated Dockerfile for `redisfield/korvet:early-access` already contained the malformed `ENTRYPOINT` before `docker build` ran.

## Solution

Add the missing closing bracket to the `JAVA_BINARY` default entrypoint string.

## Notes

This is separate from #2112, which fixes the `single-jar` Docker template. This PR fixes the `JAVA_BINARY` default value upstream in `DockerPackagerValidator`.
