### PR TITLE
fix(assemble): drop literal quotes around jlink --add-options value

### DIFF
--- a/core/jreleaser-engine/src/main/java/org/jreleaser/assemblers/JlinkAssemblerProcessor.java
+++ b/core/jreleaser-engine/src/main/java/org/jreleaser/assemblers/JlinkAssemblerProcessor.java
@@ -286,7 +286,7 @@ public class JlinkAssemblerProcessor extends AbstractAssemblerProcessor<org.jrel
             .arg("--add-modules")
             .arg(join(",", moduleNames));
         if (assembler.getJava().getJvmOptions().isSet()) {
-            cmd.arg("--add-options=\"" + join(" ", assembler.getJava().getJvmOptions().getResolvedUniversal(context)) + "\"");
+            cmd.arg("--add-options=" + join(" ", assembler.getJava().getJvmOptions().getResolvedUniversal(context)));
         }
         cmd.arg("--output")
             .arg(maybeQuote(imageDirectory.toString()));


### PR DESCRIPTION
## Summary

Fixes #2120.

When a jlink assembler defines `jvmOptions.universal`, JReleaser builds the jlink command with literally-quoted value:

```java
cmd.arg("--add-options=\"" + join(" ", ...getResolvedUniversal(context)) + "\"");
```

The arg is passed to jlink via `ProcessBuilder` (no shell), so the `"` characters become part of the option value stored in the runtime image. At JVM startup the launcher reads the value back with the quotes included and treats the entire joined option string as one malformed `-XX:+...` argument. The result is that **every** invocation of the bundled `bin/java` fails — including the trivial `bin/java --version`.

This PR removes the literal quotes so jlink receives the unquoted, space-separated option list it expects.

```diff
-            cmd.arg("--add-options=\"" + join(" ", assembler.getJava().getJvmOptions().getResolvedUniversal(context)) + "\"");
+            cmd.arg("--add-options=" + join(" ", assembler.getJava().getJvmOptions().getResolvedUniversal(context)));
```

The minimal reproducer (no JReleaser involved) and full root-cause analysis are in #2120.

## Test plan

- [x] Reproduced the failure with raw `jlink` by passing `'--add-options="...multiple options..."'` (literal quotes) — `bin/java --version` fails with `Unrecognized VM option '...'`.
- [x] Verified the same `jlink` invocation without the literal quotes produces a runtime where `bin/java --version` and the generated launcher work correctly.
- [x] Verified end-to-end against a real downstream project (riotx) with multiple universal `jvmOptions` (`-XX:+IgnoreUnrecognizedVMOptions`, `--add-opens=java.base/java.nio=ALL-UNNAMED`, `--enable-native-access=ALL-UNNAMED`, `--sun-misc-unsafe-memory-access=allow`): after applying this patch, `bin/java --version` and `bin/<distribution> --version` both succeed.