### PR TITLE
fix(jdks): drop unsupported connectTimeOut element

### DIFF
--- a/plugins/jdks-maven-plugin/src/main/java/org/jreleaser/jdks/maven/plugin/JdkHelper.java
+++ b/plugins/jdks-maven-plugin/src/main/java/org/jreleaser/jdks/maven/plugin/JdkHelper.java
@@ -124,8 +124,11 @@ public class JdkHelper {
                     element("outputDirectory", jdkExtractDirectory.getAbsolutePath()),
                     element("cacheDirectory", cacheDirectory),
                     element("outputFileName", filename),
-                    element("connectTimeOut", String.valueOf(connectTimeout * 1000)),
-                    element("readTimeOut", String.valueOf(readTimeout * 1000))
+                    // download-maven-plugin 2.1.0 does not expose a separate connect timeout
+                    // parameter; WGetMojo wires readTimeOut into both connect and socket
+                    // timeouts internally. Pass the larger of the two so neither caller-set
+                    // value is silently dropped.
+                    element("readTimeOut", String.valueOf(Math.max(connectTimeout, readTimeout) * 1000))
                 ),
                 executionEnvironment(
                     project,


### PR DESCRIPTION
Fixes #2126

## Summary

The `setup-disco` goal is currently broken in v1.24.0 because `JdkHelper` passes a `connectTimeOut` element to `download-maven-plugin` 2.1.0, but `WGetMojo` does not declare that parameter. Maven's configuration parser rejects the build with `Cannot find 'connectTimeOut' in class ... WGetMojo`. Drop the element and pass `Math.max(connectTimeout, readTimeout) * 1000` as `readTimeOut` so neither caller-set value is silently dropped.

### Context

`download-maven-plugin` 2.1.0 [`WGetMojo.java:807-808`](https://github.com/download-maven-plugin/download-maven-plugin/blob/e8c1b68c4bd5338fab1a77b9ca56430de8b498c6/src/main/java/io/github/download/maven/plugin/internal/WGetMojo.java#L807) wires `readTimeOut` into BOTH the HTTP connect timeout and the socket timeout:

```java
.withConnectTimeout(this.readTimeOut)
.withSocketTimeout(this.readTimeOut)
```

There is no separate `connectTimeOut` parameter in that plugin version, so PR #2087 introduced a configuration shape the plugin cannot parse. Every `setup-disco` invocation against v1.24.0 hard-fails at goal execution time.

## Why this matters

Two valid fixes were available:

1. Just drop the bad element. The user-facing JReleaser `connectTimeout` knob still validates and clamps via `AbstractJdksMojo`, but it gets silently ignored for the download step (because the plugin reuses `readTimeOut` internally for connect anyway).
2. Drop the bad element AND pass `Math.max(connectTimeout, readTimeout) * 1000` as `readTimeOut`. The larger user-set value becomes the effective combined timeout. Neither knob is silently dropped.

This PR takes option 2 because the JReleaser docs/parameter validation (`MINIMUM_CONNECT_TIMEOUT = 5`, `MAXIMUM_CONNECT_TIMEOUT = 300` in `AbstractJdksMojo`) imply the value is supposed to do something. Without that change, a user who set `connectTimeout = 60` and left `readTimeout` at its default (smaller) value would see their timeout silently ignored.

## Changes

- `JdkHelper.java:127` - remove the `connectTimeOut` element entirely (download-maven-plugin doesn't accept it).
- `JdkHelper.java:128` - change `readTimeout` to `Math.max(connectTimeout, readTimeout)` so the larger user-set knob wins, with a comment explaining the rationale.
- No public API change. `AbstractJdksMojo.connectTimeout` / `readTimeout` parameters and their validation are unchanged.

## How to test

- `./gradlew :jdks-maven-plugin:compileJava` passes locally.
- The original `Cannot find 'connectTimeOut'` error is rooted in maven-plugin configuration parsing, not Java compile; the fix verifiably removes the unparseable element name so the parse error class is structurally eliminated.

### Checklist

- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] All contributed code is distributable under Apache License 2.0 (this is a small edit to an existing Apache-2.0 file).
<!-- documentation update not needed: no public surface change -->

AI-assisted.
