### PR TITLE
fix(signing): skip signing validation errors when --yolo is set

### DIFF
--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/signing/SigningValidator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/signing/SigningValidator.java
@@ -46,6 +46,7 @@ import static org.jreleaser.model.api.signing.Signing.MINISIGN_PASSWORD;
 import static org.jreleaser.model.api.signing.Signing.MINISIGN_PUBLIC_KEY;
 import static org.jreleaser.model.api.signing.Signing.MINISIGN_SECRET_KEY;
 import static org.jreleaser.model.internal.validation.common.Validator.checkProperty;
+import static org.jreleaser.model.internal.validation.common.Validator.mergeErrors;
 import static org.jreleaser.model.internal.validation.common.Validator.resolveActivatable;
 import static org.jreleaser.util.CollectionUtils.listOf;
 import static org.jreleaser.util.Env.envKey;
@@ -73,9 +74,13 @@ public final class SigningValidator {
         boolean activeSet = signing.isActiveSet();
         resolveActivatable(context, signing, "signing", "");
 
-        validatePgp(context, mode, signing.getPgp(), errors);
-        validateCosign(context, mode, signing.getCosign(), errors);
-        validateMinisign(context, mode, signing.getMinisign(), errors);
+        Errors incoming = new Errors();
+        validatePgp(context, mode, signing.getPgp(), incoming);
+        mergeErrors(context, errors, incoming, signing.getPgp());
+        validateCosign(context, mode, signing.getCosign(), incoming);
+        mergeErrors(context, errors, incoming, signing.getCosign());
+        validateMinisign(context, mode, signing.getMinisign(), incoming);
+        mergeErrors(context, errors, incoming, signing.getMinisign());
 
         if (!activeSet) {
             boolean enabled = signing.getPgp().isEnabled() ||

--- a/core/jreleaser-model-impl/src/test/java/org/jreleaser/model/internal/validation/signing/SigningValidatorTest.java
+++ b/core/jreleaser-model-impl/src/test/java/org/jreleaser/model/internal/validation/signing/SigningValidatorTest.java
@@ -1,0 +1,103 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2026 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.model.internal.validation.signing;
+
+import org.jreleaser.logging.SimpleJReleaserLoggerAdapter;
+import org.jreleaser.model.Active;
+import org.jreleaser.model.api.JReleaserCommand;
+import org.jreleaser.model.api.JReleaserContext.Mode;
+import org.jreleaser.model.internal.JReleaserContext;
+import org.jreleaser.model.internal.JReleaserModel;
+import org.jreleaser.util.Errors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @since 1.25.0
+ */
+class SigningValidatorTest {
+
+    @Test
+    void signingPgpValidationFailsWithoutYolo(@TempDir Path tempDir) {
+        // Given: PGP signing active but no secret key configured
+        JReleaserContext context = createContext(tempDir, false);
+        context.getModel().getSigning().setActive(Active.ALWAYS);
+        context.getModel().getSigning().getPgp().setActive(Active.ALWAYS);
+
+        Errors errors = new Errors();
+
+        // When: validate signing
+        SigningValidator.validateSigning(context, Mode.FULL, errors);
+
+        // Then: errors should be reported
+        assertTrue(errors.hasConfigurationErrors(),
+            "Expected configuration errors when PGP secret key is missing without yolo");
+    }
+
+    @Test
+    void signingPgpValidationSkippedWithYolo(@TempDir Path tempDir) {
+        // Given: PGP signing active but no secret key configured, yolo=true
+        JReleaserContext context = createContext(tempDir, true);
+        context.getModel().getSigning().setActive(Active.ALWAYS);
+        context.getModel().getSigning().getPgp().setActive(Active.ALWAYS);
+
+        Errors errors = new Errors();
+
+        // When: validate signing with yolo
+        SigningValidator.validateSigning(context, Mode.FULL, errors);
+
+        // Then: no errors (converted to warnings), and signing should be disabled
+        assertFalse(errors.hasConfigurationErrors(),
+            "Expected no configuration errors when yolo is set");
+        assertTrue(errors.hasWarnings(),
+            "Expected warnings when yolo is set and PGP secret key is missing");
+        assertFalse(context.getModel().getSigning().getPgp().isEnabled(),
+            "Expected PGP signing to be disabled when yolo is set and secret key is missing");
+    }
+
+    private static JReleaserContext createContext(Path basedir, boolean yolo) {
+        // Use a temp dir as settings path to avoid loading ~/.jreleaser/config.properties
+        // which may contain actual credentials
+        JReleaserContext context = new JReleaserContext(
+            new SimpleJReleaserLoggerAdapter(SimpleJReleaserLoggerAdapter.Level.WARN),
+            JReleaserContext.Configurer.CLI_YAML,
+            Mode.FULL,
+            JReleaserCommand.FULL_RELEASE,
+            new JReleaserModel(),
+            basedir,
+            basedir.resolve("settings.properties"),
+            basedir.resolve("out/jreleaser"),
+            yolo,
+            true,
+            true,
+            false,
+            false,
+            Collections.emptyList(),
+            Collections.emptyList());
+        // Initialize environment properties using the temp settings path
+        // (no config.properties exists there, so no external credentials leak in)
+        context.getModel().getEnvironment().initProps(context);
+        return context;
+    }
+}


### PR DESCRIPTION
## Problem

When `signing.pgp.active: ALWAYS` is configured but the PGP secret key is not available (e.g. `JRELEASER_GPG_SECRET_KEY` is not defined), running `jreleaser release --dry-run --yolo` fails with a validation error instead of skipping signing gracefully.

## Root Cause

In `SigningValidator.validateSigning()`, validation errors from `validatePgp()`, `validateCosign()`, and `validateMinisign()` were passed directly to the parent `errors` object, bypassing the `--yolo` mechanism that other validators (e.g. `AnnouncersValidator`) use.

## Fix

Applied the same `mergeErrors` pattern used by `AnnouncersValidator`:

1. Collect validation errors in a local `Errors incoming` object
2. After each sub-validator, call `mergeErrors(context, errors, incoming, signingTool)`
3. When `--yolo` is active, `mergeErrors` converts errors to warnings and calls `disable()` on the signing tool

## Tests

Added `SigningValidatorTest` with two tests:
- **`signingPgpValidationFailsWithoutYolo`** — verifies existing behavior: missing secret key produces configuration errors
- **`signingPgpValidationSkippedWithYolo`** — verifies fix: with `--yolo`, errors become warnings and PGP signing is disabled

Fixes #2128