### PR TITLE
fix(deploy): correct GitLab projectIdentifier error message (fixes #2132)

### DIFF
--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/deploy/maven/GitlabMavenDeployerValidator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/deploy/maven/GitlabMavenDeployerValidator.java
@@ -92,7 +92,7 @@ public final class GitlabMavenDeployerValidator {
         }
 
         if (isBlank(mavenDeployer.getProjectIdentifier())) {
-            errors.configuration(RB.$("validation_must_not_be_blank", "deploy.maven.gitea." + mavenDeployer.getName() + ".projectIdentifier"));
+            errors.configuration(RB.$("validation_must_not_be_blank", "deploy.maven.gitlab." + mavenDeployer.getName() + ".projectIdentifier"));
         }
     }
 }


### PR DESCRIPTION
<!-- The issue this PR addresses -->
<!-- Please reference the issue this PR solves -->

- Fixes #2132
  - `GitlabMavenDeployerValidator` reported `deploy.maven.gitea.<name>.projectIdentifier must not be blank` when `projectIdentifier` was missing for a GitLab Maven deployer. Copy-paste typo from Gitea
  validator.
  - Corrected path prefix to `deploy.maven.gitlab` so the error message matches the deployer type.

### Context
<!-- What problem does this change address? -->
<!-- Link to relevant issues or discussions here -->

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
