### PR TITLE
fix: resolve current branch instead of assuming main

### DIFF
--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/release/BaseReleaserValidator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/release/BaseReleaserValidator.java
@@ -137,7 +137,7 @@ public final class BaseReleaserValidator {
                 BRANCH,
                 baseKey + "branch",
                 service.getBranch(),
-                "main"));
+                resolveDefaultBranch(context)));
 
         service.setBranchPush(
             checkProperty(context,
@@ -295,6 +295,21 @@ public final class BaseReleaserValidator {
                 }
             }
         }
+    }
+
+    private static String resolveDefaultBranch(JReleaserContext context) {
+        // Prefer the branch the repository is actually on (the checked-out HEAD)
+        // so repositories that still use "master" (or any non-"main" default branch)
+        // are not forced onto a non-existent "main" branch.
+        if (null != context.getModel().getCommit()) {
+            String refName = context.getModel().getCommit().getRefName();
+            if (isNotBlank(refName)) {
+                return refName;
+            }
+        }
+        // Last-resort fallback when no Git context is available (e.g. detached HEAD
+        // or standalone validation), preserving backward-compatible behavior.
+        return "main";
     }
 
     private static void validateChangelog(JReleaserContext context, BaseReleaser<?, ?> service, Errors errors) {

--- a/core/jreleaser-model-impl/src/test/java/org/jreleaser/model/internal/validation/release/BaseReleaserValidatorTest.java
+++ b/core/jreleaser-model-impl/src/test/java/org/jreleaser/model/internal/validation/release/BaseReleaserValidatorTest.java
@@ -1,0 +1,157 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2026 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.model.internal.validation.release;
+
+import org.jreleaser.logging.SimpleJReleaserLoggerAdapter;
+import org.jreleaser.model.api.JReleaserCommand;
+import org.jreleaser.model.api.JReleaserContext.Mode;
+import org.jreleaser.model.internal.JReleaserContext;
+import org.jreleaser.model.internal.JReleaserModel;
+import org.jreleaser.model.internal.release.GithubReleaser;
+import org.jreleaser.util.Errors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that the release branch is resolved from the current Git context
+ * instead of always assuming "main".
+ *
+ * @see <a href="https://github.com/jreleaser/jreleaser/issues/2118">#2118</a>
+ */
+class BaseReleaserValidatorTest {
+
+    @Test
+    void resolvesCurrentBranchWhenOnMaster(@TempDir Path tempDir) {
+        // Given: a repository checked out on "master" with no branch configured
+        JReleaserContext context = createContext(tempDir, "master");
+        GithubReleaser service = createService(context);
+
+        // When: the git service is validated
+        validateBranch(context, service);
+
+        // Then: the resolved branch is "master", not the hardcoded "main"
+        assertEquals("master", service.getBranch());
+    }
+
+    @Test
+    void resolvesCurrentBranchWhenOnMain(@TempDir Path tempDir) {
+        // Given: a repository checked out on "main" with no branch configured
+        JReleaserContext context = createContext(tempDir, "main");
+        GithubReleaser service = createService(context);
+
+        // When: the git service is validated
+        validateBranch(context, service);
+
+        // Then: the resolved branch is "main" (unchanged behavior)
+        assertEquals("main", service.getBranch());
+    }
+
+    @Test
+    void explicitlyConfiguredBranchWinsOverDetection(@TempDir Path tempDir) {
+        // Given: a repository on "master" but the branch is explicitly configured
+        JReleaserContext context = createContext(tempDir, "master");
+        GithubReleaser service = createService(context);
+        service.setBranch("release/1.x");
+
+        // When: the git service is validated
+        validateBranch(context, service);
+
+        // Then: the explicit value wins over detection
+        assertEquals("release/1.x", service.getBranch());
+    }
+
+    @Test
+    void fallsBackToMainWhenNoGitContext(@TempDir Path tempDir) {
+        // Given: no Git context (commit/refName unavailable, e.g. detached HEAD)
+        JReleaserContext context = createContext(tempDir, null);
+        GithubReleaser service = createService(context);
+
+        // When: the git service is validated
+        validateBranch(context, service);
+
+        // Then: it falls back to "main"
+        assertEquals("main", service.getBranch());
+    }
+
+    @Test
+    void fallsBackToMainWhenRefNameBlank(@TempDir Path tempDir) {
+        // Given: a Git context whose refName is blank (e.g. detached HEAD)
+        JReleaserContext context = createContext(tempDir, "");
+        GithubReleaser service = createService(context);
+
+        // When: the git service is validated
+        validateBranch(context, service);
+
+        // Then: it falls back to "main"
+        assertEquals("main", service.getBranch());
+    }
+
+    // Drives the branch-resolution portion of validateGitService. Later validation
+    // steps (e.g. tag-name template resolution) require the ExtensionManager service
+    // which is provided by jreleaser-engine and is not on this module's unit-test
+    // classpath; the branch is resolved before that point, so we tolerate a downstream
+    // failure and assert only on the resolved branch.
+    private static void validateBranch(JReleaserContext context, GithubReleaser service) {
+        try {
+            BaseReleaserValidator.validateGitService(context, Mode.FULL, service, new Errors());
+        } catch (RuntimeException ignored) {
+            // branch is already resolved before any downstream template resolution
+        }
+    }
+
+    private static GithubReleaser createService(JReleaserContext context) {
+        GithubReleaser service = new GithubReleaser();
+        service.setOwner("acme");
+        service.setName("widget");
+        service.setToken("token");
+        context.getModel().getRelease().setGithub(service);
+        return service;
+    }
+
+    private static JReleaserContext createContext(Path basedir, String refName) {
+        JReleaserContext context = new JReleaserContext(
+            new SimpleJReleaserLoggerAdapter(SimpleJReleaserLoggerAdapter.Level.WARN),
+            JReleaserContext.Configurer.CLI_YAML,
+            Mode.FULL,
+            JReleaserCommand.FULL_RELEASE,
+            new JReleaserModel(),
+            basedir,
+            basedir.resolve("settings.properties"),
+            basedir.resolve("out/jreleaser"),
+            true,
+            true,
+            true,
+            false,
+            false,
+            Collections.emptyList(),
+            Collections.emptyList());
+        context.getModel().getEnvironment().initProps(context);
+        context.getModel().getProject().setName("widget");
+        if (null != refName) {
+            context.getModel().setCommit(new org.jreleaser.model.api.JReleaserModel.Commit(
+                "abc1234", "abc1234567890", refName, 0, ZonedDateTime.now()));
+        }
+        return context;
+    }
+}


### PR DESCRIPTION
## Summary

The release branch defaulted to the literal string `main` whenever no branch was configured in the DSL or via the `JRELEASER_BRANCH` env var. Repositories whose default branch is `master` (or any non-`main` name) would fail the release because the assumed `main` branch does not exist.

This change resolves the default release branch from the current Git context (the checked-out HEAD ref already captured on the model's `Commit`) instead of assuming `main`, while keeping `main` as a last-resort fallback when no Git branch can be detected.

## Why this matters (#2118)

The reporter hit this on a `master`-based repository (MorphiaOrg/morphia). The documented workaround is to set the branch explicitly via the DSL or `JRELEASER_BRANCH`, but the hardcoded `main` default remains a footgun for the many older repositories that still use `master`. Resolving the actual checked-out branch removes that surprise without changing behavior for `main`-based repos.

## Changes

- `BaseReleaserValidator`: replace the unconditional `"main"` branch fallback with `resolveDefaultBranch(context)`, which returns the current branch (`context.getModel().getCommit().getRefName()`) when available and falls back to `"main"` only when no Git ref is detectable.
- Explicitly configured branch (DSL) and `JRELEASER_BRANCH`/property values continue to take precedence over detection, since they are still passed as the `value` argument to `checkProperty(...)`.
- The `branch.push` fallback chains off `service.getBranch()` and therefore inherits the corrected value automatically.

## Testing

Added `BaseReleaserValidatorTest` covering:
- repo on `master` with no branch configured resolves to `master`
- repo on `main` with no branch configured resolves to `main` (unchanged)
- an explicitly configured branch wins over detection
- no Git context falls back to `main`
- a blank ref name (e.g. detached HEAD) falls back to `main`

`./gradlew :jreleaser-model-impl:test --tests "*BaseReleaserValidatorTest"` passes (5/5).

Fixes #2118
