### PR TITLE
fix(assemble): Native-image archives should use the configured executable name

### DIFF
--- a/core/jreleaser-engine/src/main/java/org/jreleaser/assemblers/NativeImageAssemblerProcessor.java
+++ b/core/jreleaser-engine/src/main/java/org/jreleaser/assemblers/NativeImageAssemblerProcessor.java
@@ -158,7 +158,7 @@ public class NativeImageAssemblerProcessor extends AbstractAssemblerProcessor<or
         String finalImageName = imageName + "-" + platformReplaced;
 
         String executable = assembler.getExecutable();
-        if (!assembler.getArchiving().isEnabled()) {
+        if (!assembler.isArchive()) {
             executable = finalImageName;
         }
         String executableFileName = executable;

--- a/core/jreleaser-engine/src/test/java/org/jreleaser/assemblers/NativeImageAssemblerProcessorTest.java
+++ b/core/jreleaser-engine/src/test/java/org/jreleaser/assemblers/NativeImageAssemblerProcessorTest.java
@@ -35,6 +35,7 @@ import org.jreleaser.mustache.TemplateContext;
 import org.jreleaser.sdk.command.Command;
 import org.jreleaser.util.PlatformUtils;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -57,6 +58,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -188,6 +190,45 @@ class NativeImageAssemblerProcessorTest {
         } else {
             assertThat(exception).isNull();
         }
+    }
+
+    @Test
+    void testAssembleBinary_ArchiveUsesConfiguredExecutableName() throws Exception {
+        Artifact mainJar = mockMainJar(Mode.DEFAULT);
+        when(assembler.getMainJar()).thenReturn(mainJar);
+        when(assembler.isArchive()).thenReturn(true);
+        when(assembler.getTemplateDirectory()).thenReturn("");
+        when(assembler.getType()).thenReturn("native-image");
+        when(assembler.getSwid()).thenReturn(mock(org.jreleaser.model.internal.catalog.swid.SwidTag.class));
+
+        // Simulate native-image actually producing the binary named after the
+        // "-H:Name=" argument, since executeCommand() is otherwise a no-op mock.
+        Command.Result commandResult = mock(Command.Result.class);
+        when(commandResult.getExitValue()).thenReturn(0);
+        doAnswer(invocation -> {
+            Path parent = invocation.getArgument(0);
+            Command cmd = invocation.getArgument(1);
+            String name = cmd.getArgs().stream()
+                .filter(arg -> arg.startsWith("-H:Name="))
+                .findFirst()
+                .map(arg -> arg.substring("-H:Name=".length()))
+                .orElseThrow();
+            Files.createFile(parent.resolve(name + (PlatformUtils.isWindows() ? ".exe" : "")));
+            return commandResult;
+        }).when(nativeImageAssemblerProcessor).executeCommand(any(Path.class), any(Command.class));
+
+        nativeImageAssemblerProcessor.assemble(props);
+
+        String executableFileName = IMAGE_NAME + (PlatformUtils.isWindows() ? ".exe" : "");
+        Path binDirectory = props.<Path>get(Constants.KEY_DISTRIBUTION_ASSEMBLE_DIRECTORY)
+            .resolve(NativeImageAssemblerProcessor.WORK_DIRECTORY)
+            .resolve(IMAGE_NAME + "-" + DETECTED_OS_ARCH)
+            .resolve(NativeImageAssemblerProcessor.BIN_DIRECTORY);
+
+        // The archived binary must keep the configured executable name (e.g. "jreleaser"),
+        // not the fully versioned/platformed image name, see #2146.
+        assertThat(binDirectory.resolve(executableFileName)).exists();
+        assertThat(binDirectory.resolve(IMAGE_NAME + "-" + DETECTED_OS_ARCH)).doesNotExist();
     }
 
     private void testAssembleBinary(Command expectedCommand) throws Exception {


### PR DESCRIPTION
Fixes #2146

### Context

In 1.25.0, native-image archives contain the binary renamed from `jreleaser` to `jreleaser-native-<version>-<platform>`, breaking tools like mise and sdkman that expect a stable `bin/jreleaser` path.

### Root cause

Commit 14044621f ("Resolve native-image distribution artifacts with multiple archive formats") migrated most of `NativeImageAssemblerProcessor` from the deprecated `assembler.getArchiving().isEnabled()` check to the new `assembler.isArchive()`, but missed one spot: the code that decides whether the binary copied into the archive keeps its configured `executable` name or falls back to the fully versioned/platformed image name.

Since `archiving.enabled` is a deprecated, separate flag that defaults to `false` (and jreleaser's own `jreleaser.yml`, like most 1.25.0+ configs, uses the new `archive`/`formats` properties instead), `assembler.getArchiving().isEnabled()` now always evaluates to `false` for the default configuration, causing the binary to always be renamed to the versioned image name inside the archive - regardless of the `executable` setting.

### Describe the solution

Changed the check to use `assembler.isArchive()`, consistent with the rest of the method (and with `doAssemble()`), so the archived binary correctly keeps the configured `executable` name (e.g. `jreleaser`) when archiving is enabled (which is the default), and only falls back to the versioned image name when archiving is disabled (i.e. a standalone binary is produced, where the fuller name helps disambiguate it).

### Testing

Added `testAssembleBinary_ArchiveUsesConfiguredExecutableName`, which simulates a native-image build with `isArchive() == true` and asserts the resulting `bin/` directory contains the binary under the configured `executable` name rather than the versioned image name. Ran the full `NativeImageAssemblerProcessorTest` and all `org.jreleaser.assemblers.*` tests locally; all pass (`./gradlew :jreleaser-engine:test`).

### Checklist
- [x] Reviewed Contribution Guidelines.
- [x] Code is licensed under Apache License 2.0.
- [ ] Documentation update - not applicable, this restores previously documented/expected behavior.