### PR TITLE
feat(brewPackagerValidator): improve warnings for incompatible distribution types

### DIFF
--- a/api/jreleaser-resource-bundle/src/main/resources/org/jreleaser/bundle/Messages.properties
+++ b/api/jreleaser-resource-bundle/src/main/resources/org/jreleaser/bundle/Messages.properties
@@ -369,6 +369,7 @@ WARNING.validation.packager.multiple.artifacts = distribution.{}.{} was disabled
 WARNING.validation.uploader.no.artifacts       = upload.{}.{} was disabled because there are no matching artifacts
 WARNING.validation.docker.buildx.no.platforms  = distribution.{}.docker was disabled because buildx defines no platforms
 WARNING.validation.docker.buildx.distributions = distribution.{}.docker was disabled because buildx defines only supports {} distributions
+WARNING.validation.packager.incompatible.distribution.type = distribution.{}.{} artifact extension(s) {} are not supported for {} distributions; consider switching the distribution type to one of: {}
 
 validation.disabled                      = - disabled
 validation.disabled.error                = - disabled because validation failed

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/packagers/BrewPackagerValidator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/packagers/BrewPackagerValidator.java
@@ -122,6 +122,7 @@ public final class BrewPackagerValidator {
             context.getLogger().debug(RB.$("validation.disabled.no.artifacts"));
             errors.warning(RB.$("WARNING.validation.packager.no.artifacts", distribution.getName(),
                 packager.getType(), packager.getSupportedFileExtensions(distribution.getType())));
+            warnIncompatibleDistributionType(distribution, packager, errors);
             packager.disable();
             return;
         }
@@ -298,5 +299,26 @@ public final class BrewPackagerValidator {
                     distributions.stream().map(Distribution::getName).collect(Collectors.joining(", "))));
             }
         });
+    }
+
+    private static void warnIncompatibleDistributionType(Distribution distribution, BrewPackager packager, Errors errors) {
+        Set<String> actualExtensions = distribution.getArtifacts().stream()
+            .map(a -> org.jreleaser.util.FileType.getExtension(a.getPath()))
+            .filter(ext -> !ext.isEmpty())
+            .collect(Collectors.toSet());
+
+        List<org.jreleaser.model.Distribution.DistributionType> compatibleTypes =
+            java.util.Arrays.stream(org.jreleaser.model.Distribution.DistributionType.values())
+                .filter(type -> type != distribution.getType())
+                .filter(packager::supportsDistribution)
+                .filter(type -> actualExtensions.stream()
+                    .anyMatch(ext -> packager.getSupportedFileExtensions(type).contains(ext)))
+                .collect(Collectors.toList());
+
+        if (!compatibleTypes.isEmpty()) {
+            errors.warning(RB.$("WARNING.validation.packager.incompatible.distribution.type",
+                distribution.getName(), packager.getType(), distribution.getType(),
+                actualExtensions, compatibleTypes));
+        }
     }
 }

--- a/core/jreleaser-model-impl/src/test/java/org/jreleaser/model/internal/validation/packagers/BrewPackagerValidatorTest.java
+++ b/core/jreleaser-model-impl/src/test/java/org/jreleaser/model/internal/validation/packagers/BrewPackagerValidatorTest.java
@@ -1,0 +1,128 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2026 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.model.internal.validation.packagers;
+
+import org.jreleaser.logging.SimpleJReleaserLoggerAdapter;
+import org.jreleaser.model.Active;
+import org.jreleaser.model.Distribution.DistributionType;
+import org.jreleaser.model.api.JReleaserCommand;
+import org.jreleaser.model.api.JReleaserContext.Mode;
+import org.jreleaser.model.internal.JReleaserContext;
+import org.jreleaser.model.internal.JReleaserModel;
+import org.jreleaser.model.internal.common.Artifact;
+import org.jreleaser.model.internal.distributions.Distribution;
+import org.jreleaser.model.internal.packagers.BrewPackager;
+import org.jreleaser.model.internal.release.GithubReleaser;
+import org.jreleaser.util.Errors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Harsh Mehta
+ * @since 1.26.0
+ */
+class BrewPackagerValidatorTest {
+
+    @Test
+    void brewDisabledWithHintWhenJavaBinaryDistributionHasJarArtifact(@TempDir Path tempDir) {
+        JReleaserContext context = createContext(tempDir);
+
+        Distribution distribution = new Distribution();
+        distribution.setName("myapp");
+        distribution.setActive(Active.ALWAYS);
+        distribution.setType(DistributionType.JAVA_BINARY);
+
+        Artifact artifact = new Artifact();
+        artifact.setPath("myapp-1.0.jar");
+        artifact.setActive(Active.ALWAYS);
+        distribution.addArtifact(artifact);
+
+        BrewPackager packager = new BrewPackager();
+        packager.setActive(Active.ALWAYS);
+
+        context.getModel().getPackagers().getBrew().setActive(Active.ALWAYS);
+
+        Errors errors = new Errors();
+        BrewPackagerValidator.validateBrew(context, distribution, packager, errors);
+
+        assertTrue(errors.hasWarnings(), "Expected warnings for JAVA_BINARY + jar artifact");
+        assertFalse(packager.isEnabled(), "Expected brew packager to be disabled");
+
+        String warnings = errors.warningsAsString();
+        assertTrue(warnings.contains("distribution.myapp.brew was disabled because there are no matching artifacts"),
+            "Expected generic disable warning: " + warnings);
+        assertTrue(warnings.contains(".jar") && warnings.contains("JAVA_BINARY"),
+            "Expected hint mentioning .jar and JAVA_BINARY: " + warnings);
+        assertTrue(warnings.contains("SINGLE_JAR"),
+            "Expected hint to suggest SINGLE_JAR as compatible type: " + warnings);
+    }
+
+    @Test
+    void brewNotDisabledWhenJavaBinaryDistributionHasZipArtifact(@TempDir Path tempDir) {
+        JReleaserContext context = createContext(tempDir);
+
+        Distribution distribution = new Distribution();
+        distribution.setName("myapp");
+        distribution.setActive(Active.ALWAYS);
+        distribution.setType(DistributionType.JAVA_BINARY);
+
+        Artifact artifact = new Artifact();
+        artifact.setPath("myapp-1.0.zip");
+        artifact.setActive(Active.ALWAYS);
+        distribution.addArtifact(artifact);
+
+        BrewPackager packager = new BrewPackager();
+        packager.setActive(Active.ALWAYS);
+
+        context.getModel().getPackagers().getBrew().setActive(Active.ALWAYS);
+
+        Errors errors = new Errors();
+        BrewPackagerValidator.validateBrew(context, distribution, packager, errors);
+
+        assertFalse(errors.warningsAsString().contains("SINGLE_JAR"),
+            "Expected no SINGLE_JAR hint when .zip artifact is present");
+    }
+
+    private static JReleaserContext createContext(Path basedir) {
+        JReleaserModel model = new JReleaserModel();
+        model.getRelease().setGithub(new GithubReleaser());
+
+        return new JReleaserContext(
+            new SimpleJReleaserLoggerAdapter(SimpleJReleaserLoggerAdapter.Level.WARN),
+            JReleaserContext.Configurer.CLI_YAML,
+            Mode.FULL,
+            JReleaserCommand.FULL_RELEASE,
+            model,
+            basedir,
+            basedir.resolve("settings.properties"),
+            basedir.resolve("out/jreleaser"),
+            false,
+            true,
+            true,
+            false,
+            false,
+            Collections.emptyList(),
+            Collections.emptyList());
+    }
+}


### PR DESCRIPTION
<!-- The issue this PR addresses -->
<!-- Please reference the issue this PR solves -->
Fixes https://github.com/jreleaser/jreleaser/issues/2124

### Context
see : #2148

Implement generic validation logic using `supportsDistribution()` and `getSupportedFileExtensions()` instead of hardcoding JAVA_BINARY-specific checks, so the warning message adapts to any unsupported distribution type.


### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
