### PR TITLE
fix(gradle): support isolated projects in config task

### DIFF
--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/GradleJReleaserModelPrinter.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/GradleJReleaserModelPrinter.groovy
@@ -36,9 +36,17 @@ class GradleJReleaserModelPrinter extends JReleaserModelPrinter {
         this(project, newPrintWriter(System.out))
     }
 
+    GradleJReleaserModelPrinter(AnsiConsole console) {
+        this(console, newPrintWriter(System.out))
+    }
+
     GradleJReleaserModelPrinter(Project project, PrintWriter out) {
+        this(new AnsiConsole(project, 'JRELEASER'), out)
+    }
+
+    GradleJReleaserModelPrinter(AnsiConsole console, PrintWriter out) {
         super(out)
-        this.console = new AnsiConsole(project, 'JRELEASER')
+        this.console = console
     }
 
     @Override

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/JReleaserGradleProjectCapture.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/JReleaserGradleProjectCapture.groovy
@@ -88,15 +88,14 @@ class JReleaserGradleProjectCapture implements Serializable {
 
     private static Map <String, Serializable> captureGradleProjectSerializableProperties(
         Project gradleProject, JReleaserLogger logger) {
-        Set<String> propertyKeys = collectGradleProjectPropertyKeys(gradleProject)
+        Map<String, Object> properties = collectGradleProjectProperties(gradleProject)
         Map <String, Serializable> projectProperties = [:]
-        propertyKeys.each { key ->
+        properties.each { key, value ->
             // Avoid useless Gradle deprecation log
             if (GRADLE_DEPRECATED_PROJECT_PROPS.contains(key)) {
                 logger.debug("GradleProjectCapture: IGNORE deprecated Gradle project property '${key}'.")
                 return // continue
             }
-            Object value = gradleProject.findProperty(key)
             if (value instanceof Provider) {
                 Provider p = (Provider) value
                 value = p.present ? p.get() : null
@@ -116,15 +115,28 @@ class JReleaserGradleProjectCapture implements Serializable {
         return projectProperties
     }
 
-    private static Set<String> collectGradleProjectPropertyKeys(Project gradleProject) {
-        Set<String> propertyKeys = gradleProject.properties.keySet()
-        ExtraPropertiesExtension extraPropertiesExtension = gradleProject.extensions.extraProperties
-        Set<String> extraPropertyKeys = extraPropertiesExtension?.properties?.keySet()
-        if (extraPropertyKeys) {
-            propertyKeys += extraPropertyKeys
-            propertyKeys = propertyKeys.toSet()
+    private static Map<String, Object> collectGradleProjectProperties(Project gradleProject) {
+        Map<String, Object> properties = [
+            'name': gradleProject.name,
+            'group': gradleProject.group,
+            'version': gradleProject.version,
+            'description': gradleProject.description,
+            'path': gradleProject.path,
+            'displayName': gradleProject.displayName,
+            'projectDir': gradleProject.layout.projectDirectory.asFile,
+            'rootDir': gradleProject.rootProject.layout.projectDirectory.asFile,
+            'buildDir': gradleProject.layout.buildDirectory.get().asFile
+        ]
+        Provider<Map<String, String>> gradleProperties = gradleProject.providers.gradlePropertiesPrefixedBy('')
+        if (gradleProperties.present) {
+            properties.putAll(gradleProperties.get())
         }
-        return propertyKeys
+        ExtraPropertiesExtension extraPropertiesExtension = gradleProject.extensions.extraProperties
+        Map<String, Object> extraProperties = extraPropertiesExtension?.properties
+        if (extraProperties) {
+            properties.putAll(extraProperties)
+        }
+        return properties
     }
 
     Map<String, Serializable> getProperties() {

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/JReleaserLoggerService.java
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/JReleaserLoggerService.java
@@ -66,6 +66,10 @@ public abstract class JReleaserLoggerService implements BuildService<JReleaserLo
         return logger;
     }
 
+    public AnsiConsole getConsole() {
+        return getParameters().getConsole().get();
+    }
+
     @Override
     public void close() {
         logger.close();

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserConfigTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserConfigTask.groovy
@@ -128,7 +128,7 @@ abstract class JReleaserConfigTask extends AbstractPlatformAwareJReleaserTask {
 
         JReleaserContext context = createContext()
         ModelValidator.validate(context)
-        new GradleJReleaserModelPrinter(project)
+        new GradleJReleaserModelPrinter(jlogger.get().console)
             .print(context.model.asMap(full.get()))
         context.report()
     }


### PR DESCRIPTION
Fixes #2150

### Summary
- Avoid `Project.getProperties()` when capturing Gradle project properties for JReleaser tasks.
- Capture Gradle properties through `ProviderFactory.gradlePropertiesPrefixedBy("")`, plus extra properties and stable project fields.
- Reuse the configured logger console when printing `jreleaserConfig` output so the task does not access `project` during execution.

### Verification
- `./gradlew :jreleaser-gradle-plugin:compileGroovy`
- `./gradlew :jreleaser-gradle-plugin:publishToMavenLocal`
- Gradle 9.6.1 reproducer with `org.gradle.configuration-cache=true` and `org.gradle.unsafe.isolated-projects=true`: `gradle clean jreleaserConfig --stacktrace` stores and reuses the configuration cache successfully.

### Disclosure
This contribution was prepared with AI assistance and reviewed before submission.