### PR TITLE
fix: Make the mavenCentral deployer resilient to transient Central Portal failures

### DIFF
--- a/api/jreleaser-resource-bundle/src/main/resources/org/jreleaser/bundle/Messages.properties
+++ b/api/jreleaser-resource-bundle/src/main/resources/org/jreleaser/bundle/Messages.properties
@@ -881,6 +881,7 @@ maven.central.upload.bundle             = Uploading {}
 maven.central.bundled.uploaded          = Bundle {} uploaded as deployment {}
 maven.central.publish.deployment        = Publishing deployment {}
 maven.central.deployment.status         = querying status for deployment {}
+maven.central.published.check           = checking if {}:{}:{} is published
 WARN_maven_central_publication_timeout  = Deployment timeout exceeded. However, the remote operation may still be successful. Please log into Maven Central and check the status for deployment {}
 ERROR_maven_central_find_deployment     = Could not find a deployment for {}
 ERROR_maven_central_create_bundle       = Could not create deployment bundle {}

--- a/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/MavenCentral.java
+++ b/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/MavenCentral.java
@@ -108,12 +108,12 @@ public class MavenCentral {
     }
 
     public boolean isPublished(String groupId, String artifactId, String version) throws MavenCentralException {
-        Optional<PublishedStatus> status = wrap(() -> {
+        PublishedStatus status = wrap(() -> {
             context.getLogger().debug(RB.$("maven.central.published.check"), groupId, artifactId, version);
-            return Optional.ofNullable(api.published(groupId, artifactId, version));
+            return api.published(groupId, artifactId, version);
         });
 
-        return null != status && status.map(PublishedStatus::isPublished).orElse(false);
+        return null != status && status.isPublished();
     }
 
     public Optional<Deployment> status(String deploymentId) throws MavenCentralException {

--- a/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/MavenCentral.java
+++ b/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/MavenCentral.java
@@ -36,13 +36,12 @@ import org.jreleaser.bundle.RB;
 import org.jreleaser.logging.JReleaserLogger;
 import org.jreleaser.model.Http;
 import org.jreleaser.model.api.JReleaserContext;
-import org.jreleaser.model.spi.deploy.maven.Deployable;
-import org.jreleaser.mustache.Templates;
 import org.jreleaser.sdk.commons.ClientUtils;
 import org.jreleaser.sdk.commons.feign.TokenAuthRequestInterceptor;
 import org.jreleaser.sdk.mavencentral.api.Deployment;
 import org.jreleaser.sdk.mavencentral.api.MavenCentralAPI;
 import org.jreleaser.sdk.mavencentral.api.MavenCentralAPIException;
+import org.jreleaser.sdk.mavencentral.api.PublishedStatus;
 import org.jreleaser.sdk.mavencentral.api.State;
 
 import java.io.IOException;
@@ -62,7 +61,6 @@ import java.util.concurrent.Callable;
 import static java.lang.System.lineSeparator;
 import static java.util.Objects.requireNonNull;
 import static org.jreleaser.util.IoUtils.newInputStreamReader;
-import static org.jreleaser.util.StringUtils.isNotBlank;
 import static org.jreleaser.util.StringUtils.requireNonBlank;
 
 /**
@@ -109,18 +107,13 @@ public class MavenCentral {
             .target(MavenCentralAPI.class, apiHost);
     }
 
-    public boolean artifactExists(Deployable deployable, String verifyUrl) {
-        if (isNotBlank(verifyUrl)) {
-            verifyUrl = Templates.resolveTemplate(context.getLogger(), verifyUrl, deployable.props());
-            if (ClientUtils.head(context.getLogger(), verifyUrl, connectTimeout, readTimeout)) {
-                context.getLogger().warn(" ! " + RB.$("nexus.deploy.artifact.exists",
-                    deployable.getDeployPath(),
-                    deployable.getLocalPath().getFileName().toString()));
-                return true;
-            }
-        }
+    public boolean isPublished(String groupId, String artifactId, String version) throws MavenCentralException {
+        Optional<PublishedStatus> status = wrap(() -> {
+            context.getLogger().debug(RB.$("maven.central.published.check"), groupId, artifactId, version);
+            return Optional.ofNullable(api.published(groupId, artifactId, version));
+        });
 
-        return false;
+        return null != status && status.map(PublishedStatus::isPublished).orElse(false);
     }
 
     public Optional<Deployment> status(String deploymentId) throws MavenCentralException {

--- a/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/MavenCentral.java
+++ b/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/MavenCentral.java
@@ -251,9 +251,14 @@ public class MavenCentral {
             RetryPolicy<R> policy = RetryPolicy.<R>builder()
                 .handle(IllegalStateException.class)
                 .handleIf(exception -> {
-                    if (exception instanceof MavenCentralAPIException) {
-                        MavenCentralAPIException mavenCentralException = (MavenCentralAPIException) exception;
-                        return !mavenCentralException.isUnauthorized();
+                    for (Throwable cause = exception; null != cause; cause = cause.getCause()) {
+                        if (cause instanceof MavenCentralAPIException) {
+                            MavenCentralAPIException mavenCentralException = (MavenCentralAPIException) cause;
+                            return !mavenCentralException.isUnauthorized();
+                        }
+                        if (cause instanceof RetryableException) {
+                            return true;
+                        }
                     }
 
                     return false;

--- a/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/MavenCentral.java
+++ b/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/MavenCentral.java
@@ -113,7 +113,7 @@ public class MavenCentral {
             return api.published(groupId, artifactId, version);
         });
 
-        return null != status && status.isPublished();
+        return status.isPublished();
     }
 
     public Optional<Deployment> status(String deploymentId) throws MavenCentralException {

--- a/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/MavenCentral.java
+++ b/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/MavenCentral.java
@@ -287,7 +287,7 @@ public class MavenCentral {
                 return exception;
             }
 
-            if (response.status() >= 500) {
+            if (response.status() >= 500 || 429 == response.status()) {
                 logger.trace(response.request().httpMethod() + " " + response.request().url());
                 logger.trace(response.status() + " " + response.reason());
                 if (null != response.body() && null != response.body().length() && response.body().length() > 0) {

--- a/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/MavenCentralMavenDeployer.java
+++ b/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/MavenCentralMavenDeployer.java
@@ -201,15 +201,26 @@ public class MavenCentralMavenDeployer extends AbstractMavenDeployer<org.jreleas
     private Optional<String> uploadArtifacts(MavenCentral mavenCentral, Path bundleZip) throws DeployException {
         context.getLogger().info(" - {}", bundleZip.getFileName());
 
-        boolean success = true;
-        for (Deployable deployable : collectDeployableArtifacts()) {
-            if (mavenCentral.artifactExists(deployable, context.getModel().getProject().isSnapshot() ? null : getDeployer().getVerifyUrl())) {
-                success = false;
+        if (!context.getModel().getProject().isSnapshot() && !context.isDryrun()) {
+            boolean success = true;
+            for (Deployable deployable : collectDeployableArtifacts()) {
+                if (!deployable.isPom()) continue;
+                try {
+                    if (mavenCentral.isPublished(deployable.getGroupId(), deployable.getArtifactId(), deployable.getVersion())) {
+                        context.getLogger().warn(" ! " + RB.$("nexus.deploy.artifact.exists",
+                            deployable.getDeployPath(),
+                            deployable.getLocalPath().getFileName().toString()));
+                        success = false;
+                    }
+                } catch (MavenCentralException e) {
+                    context.getLogger().trace(e);
+                    throw new DeployException(RB.$("ERROR_unexpected_error"), e);
+                }
             }
-        }
 
-        if (!success) {
-            throw new DeployException(RB.$("ERROR_nexus_deploy_artifacts"));
+            if (!success) {
+                throw new DeployException(RB.$("ERROR_nexus_deploy_artifacts"));
+            }
         }
 
         if (!context.isDryrun()) {

--- a/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/api/MavenCentralAPI.java
+++ b/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/api/MavenCentralAPI.java
@@ -47,7 +47,7 @@ public interface MavenCentralAPI {
     @Headers("Content-Type: application/json")
     Deployment status(@QueryMap Map<String, Object> params);
 
-    @RequestLine("GET /published")
+    @RequestLine("GET /published?namespace={namespace}&name={name}&version={version}")
     @Headers("Content-Type: application/json")
-    Deployment published(@Param("namespace") String namespace, @Param("name") String name, @Param("version") String version);
+    PublishedStatus published(@Param("namespace") String namespace, @Param("name") String name, @Param("version") String version);
 }

--- a/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/api/PublishedStatus.java
+++ b/sdks/jreleaser-mavencentral-java-sdk/src/main/java/org/jreleaser/sdk/mavencentral/api/PublishedStatus.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2026 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.sdk.mavencentral.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * @author Andres Almiray
+ * @since 1.26.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PublishedStatus {
+    private boolean published;
+
+    public boolean isPublished() {
+        return published;
+    }
+
+    public void setPublished(boolean published) {
+        this.published = published;
+    }
+}

--- a/sdks/jreleaser-mavencentral-java-sdk/src/test/java/org/jreleaser/sdk/mavencentral/MavenCentralErrorDecoderTest.java
+++ b/sdks/jreleaser-mavencentral-java-sdk/src/test/java/org/jreleaser/sdk/mavencentral/MavenCentralErrorDecoderTest.java
@@ -77,6 +77,15 @@ class MavenCentralErrorDecoderTest {
 
 
     @Test
+    void returnsRetryableExceptionFor429() {
+        MavenCentral.MavenCentralErrorDecoder decoder = new MavenCentral.MavenCentralErrorDecoder(logger, "testDeployer");
+        Response response = buildResponse(429, "Too Many Requests");
+        Exception ex = decoder.decode("method", response);
+        assertThat(ex).isInstanceOf(RetryableException.class);
+    }
+
+
+    @Test
     void returnsDefaultExceptionForOtherStatus() {
         MavenCentral.MavenCentralErrorDecoder decoder = new MavenCentral.MavenCentralErrorDecoder(logger, "testDeployer");
         Response response = buildResponse(404, "Not Found");

--- a/sdks/jreleaser-mavencentral-java-sdk/src/test/java/org/jreleaser/sdk/mavencentral/MavenCentralRetryTest.java
+++ b/sdks/jreleaser-mavencentral-java-sdk/src/test/java/org/jreleaser/sdk/mavencentral/MavenCentralRetryTest.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2026 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.sdk.mavencentral;
+
+import dev.failsafe.FailsafeException;
+import feign.Request;
+import feign.RequestTemplate;
+import feign.RetryableException;
+import org.jreleaser.logging.JReleaserLogger;
+import org.jreleaser.logging.SimpleJReleaserLoggerAdapter;
+import org.jreleaser.sdk.mavencentral.api.MavenCentralAPIException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MavenCentralRetryTest {
+    private final JReleaserLogger logger = new SimpleJReleaserLoggerAdapter();
+
+    @Test
+    void retrierRetriesWrappedTransientFailures() {
+        MavenCentral.Retrier retrier = new MavenCentral.Retrier(logger, 1, 2);
+        AtomicInteger attempts = new AtomicInteger();
+
+        String result = retrier.retry(r -> false, () -> {
+            if (attempts.incrementAndGet() == 1) {
+                throw new MavenCentralException("transient failure", retryable503());
+            }
+            return "ok";
+        });
+
+        assertThat(result).isEqualTo("ok");
+        assertThat(attempts.get()).isEqualTo(2);
+    }
+
+    @Test
+    void retrierRetriesWrappedApiExceptions() {
+        MavenCentral.Retrier retrier = new MavenCentral.Retrier(logger, 1, 2);
+        AtomicInteger attempts = new AtomicInteger();
+
+        String result = retrier.retry(r -> false, () -> {
+            if (attempts.incrementAndGet() == 1) {
+                throw new MavenCentralException("transient failure",
+                    new MavenCentralAPIException(503, "Service Unavailable"));
+            }
+            return "ok";
+        });
+
+        assertThat(result).isEqualTo("ok");
+        assertThat(attempts.get()).isEqualTo(2);
+    }
+
+    @Test
+    void retrierDoesNotRetryUnauthorized() {
+        MavenCentral.Retrier retrier = new MavenCentral.Retrier(logger, 1, 2);
+        AtomicInteger attempts = new AtomicInteger();
+
+        assertThatThrownBy(() -> retrier.retry(r -> false, () -> {
+            attempts.incrementAndGet();
+            throw new MavenCentralException("fatal failure",
+                new MavenCentralAPIException(401, "Unauthorized"));
+        })).isInstanceOf(FailsafeException.class)
+            .hasRootCauseInstanceOf(MavenCentralAPIException.class);
+
+        assertThat(attempts.get()).isEqualTo(1);
+    }
+
+    private RetryableException retryable503() {
+        Request request = Request.create(Request.HttpMethod.HEAD, "http://localhost", Collections.emptyMap(), null,
+            new RequestTemplate());
+        return new RetryableException(503, "Service Unavailable", Request.HttpMethod.HEAD, (Long) null, request);
+    }
+}

--- a/sdks/jreleaser-mavencentral-java-sdk/src/test/java/org/jreleaser/sdk/mavencentral/MavenCentralRetryTest.java
+++ b/sdks/jreleaser-mavencentral-java-sdk/src/test/java/org/jreleaser/sdk/mavencentral/MavenCentralRetryTest.java
@@ -84,8 +84,7 @@ class MavenCentralRetryTest {
     }
 
     private RetryableException retryable503() {
-        Request request = Request.create(Request.HttpMethod.HEAD, "http://localhost", Collections.emptyMap(), null,
-            new RequestTemplate());
-        return new RetryableException(503, "Service Unavailable", Request.HttpMethod.HEAD, (Long) null, request);
+        return new RetryableException(503, "Service Unavailable", Request.HttpMethod.HEAD, (Long) null,
+            Request.create(Request.HttpMethod.HEAD, "http://localhost", Collections.emptyMap(), null, new RequestTemplate()));
     }
 }

--- a/sdks/jreleaser-mavencentral-java-sdk/src/test/java/org/jreleaser/sdk/mavencentral/api/PublishedStatusTest.java
+++ b/sdks/jreleaser-mavencentral-java-sdk/src/test/java/org/jreleaser/sdk/mavencentral/api/PublishedStatusTest.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2026 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.sdk.mavencentral.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PublishedStatusTest {
+    @Test
+    void deserializesPublishedResponse() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        assertThat(mapper.readValue("{\"published\":true}", PublishedStatus.class).isPublished()).isTrue();
+        assertThat(mapper.readValue("{\"published\":false}", PublishedStatus.class).isPublished()).isFalse();
+        assertThat(mapper.readValue("{\"published\":true,\"unknown\":1}", PublishedStatus.class).isPublished()).isTrue();
+    }
+}


### PR DESCRIPTION
Fixes #2152

### Context

- I have started using JReleaser for a five-module monorepo. Deploying the multi-module release with the `mavenCentral` deployer issues one un-retried HEAD request per file against repo1.maven.org (100+ requests), and a single transient 503 aborts the whole deployment before anything is uploaded.
- This PR replaces the per-file probes with one authenticated `GET /published` call per GAV (the approach used by other Portal clients such as sbt, Sentry craft, and mvnpm), reducing a chance of 503, and fixes the state-polling Retrier so transient 5xx errors are retried while 401 still fails fast.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
