### PR TITLE
feat(core): Add an option to override DSL values via envvars/sysprops

### DIFF
--- a/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/environment/Environment.java
+++ b/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/environment/Environment.java
@@ -27,9 +27,13 @@ import java.util.Properties;
  * @since 0.1.0
  */
 public interface Environment extends Domain {
+    String ENVIRONMENT_OVERRIDE = "ENVIRONMENT_OVERRIDE";
+
     Properties getVars();
 
     String getVariables();
+
+    boolean isOverride();
 
     Map<String, Object> getProperties();
 

--- a/api/jreleaser-resource-bundle/src/main/resources/org/jreleaser/bundle/Messages.properties
+++ b/api/jreleaser-resource-bundle/src/main/resources/org/jreleaser/bundle/Messages.properties
@@ -532,6 +532,7 @@ environment.load.variables           = Loading variables from {}
 environment.load.variables.dir       = {} is a directory. Skipping
 environment.variables.load.error     = Could not load variables from {}
 environment.variables.source.missing = Variables source {} does not exist
+environment.override.enabled         = Environment variables and System properties override explicitly configured values
 
 ERROR_unexpected_glob_resolve = Unexpected error resolving glob {}
 ERROR_glob_resolve            = Could not resolve glob {}

--- a/api/jreleaser-utils/src/main/java/org/jreleaser/util/Env.java
+++ b/api/jreleaser-utils/src/main/java/org/jreleaser/util/Env.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.stream.Collectors.toList;
 import static org.jreleaser.util.StringUtils.isBlank;
@@ -37,8 +38,18 @@ public final class Env {
     public static final String JRELEASER_ENV_PREFIX = "JRELEASER_";
     public static final String JRELEASER_SYS_PREFIX = "jreleaser.";
 
+    private static final AtomicBoolean OVERRIDE = new AtomicBoolean(false);
+
     private Env() {
         // noop
+    }
+
+    public static boolean isOverride() {
+        return OVERRIDE.get();
+    }
+
+    public static void setOverride(boolean override) {
+        OVERRIDE.set(override);
     }
 
     public static String toVar(String str) {
@@ -66,51 +77,59 @@ public final class Env {
     }
 
     public static String env(String key, String value) {
-        if (isNotBlank(value)) {
+        if (!isOverride() && isNotBlank(value)) {
             return value;
         }
-        return System.getenv(envKey(key));
+
+        String envValue = System.getenv(envKey(key));
+        return isNotBlank(envValue) ? envValue : value;
     }
 
     public static String env(Collection<String> keys, String value) {
-        if (isNotBlank(value)) {
+        if (!isOverride() && isNotBlank(value)) {
             return value;
         }
 
-        return keys.stream()
+        String envValue = keys.stream()
             .map(Env::envKey)
             .filter(key -> System.getenv().containsKey(key))
             .map(System::getenv)
             .findFirst()
             .orElse(null);
+
+        return isNotBlank(envValue) ? envValue : value;
     }
 
     public static String sys(String key, String value) {
-        if (isNotBlank(value)) {
+        if (!isOverride() && isNotBlank(value)) {
             return value;
         }
-        return System.getProperty(sysKey(key));
+
+        String sysValue = System.getProperty(sysKey(key));
+        return isNotBlank(sysValue) ? sysValue : value;
     }
 
     public static String sys(Collection<String> keys, String value) {
-        if (isNotBlank(value)) {
+        if (!isOverride() && isNotBlank(value)) {
             return value;
         }
 
-        return keys.stream()
+        String sysValue = keys.stream()
             .map(Env::sysKey)
             .filter(key -> System.getProperties().containsKey(key))
             .map(System::getProperty)
             .findFirst()
             .orElse(null);
+
+        return isNotBlank(sysValue) ? sysValue : value;
     }
 
     public static String resolve(String key, String value) {
-        return env(key, sys(key, value));
+        return isOverride() ? sys(key, env(key, value)) : env(key, sys(key, value));
     }
 
     public static String resolveOrDefault(String key, String value, String defaultValue) {
-        String result = env(key, sys(key, value));
+        String result = resolve(key, value);
         return isNotBlank(result) ? result : defaultValue;
     }
 
@@ -126,29 +145,19 @@ public final class Env {
     }
 
     public static String check(Collection<String> keys, Properties values, String property, String dsl, String configFilePath, Errors errors) {
-        List<String> sysKeys = keys.stream()
-            .map(Env::sysKey)
-            .collect(toList());
+        return check(keys, resolve(keys, values), property, dsl, configFilePath, errors);
+    }
 
-        List<String> envKeys = keys.stream()
-            .map(Env::envKey)
-            .collect(toList());
-
-        String value = sysKeys.stream()
-            .filter(System.getProperties()::containsKey)
-            .map(System::getProperty)
-            .findFirst()
-            .orElse(null);
-
+    public static String check(Collection<String> keys, String value, String property, String dsl, String configFilePath, Errors errors) {
         if (isBlank(value)) {
-            value = envKeys.stream()
-                .filter(values::containsKey)
-                .map(values::getProperty)
-                .findFirst()
-                .orElse(null);
-        }
+            List<String> sysKeys = keys.stream()
+                .map(Env::sysKey)
+                .collect(toList());
 
-        if (isBlank(value)) {
+            List<String> envKeys = keys.stream()
+                .map(Env::envKey)
+                .collect(toList());
+
             errors.configuration(RB.$("ERROR_environment_property_check2",
                 property, dsl, sysKeys, envKeys, configFilePath, envKeys));
         }

--- a/api/jreleaser-utils/src/test/java/org/jreleaser/util/EnvTests.java
+++ b/api/jreleaser-utils/src/test/java/org/jreleaser/util/EnvTests.java
@@ -17,12 +17,16 @@
  */
 package org.jreleaser.util;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junitpioneer.jupiter.ClearSystemProperty;
 import org.junitpioneer.jupiter.ReadsEnvironmentVariable;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
+import org.junitpioneer.jupiter.SetSystemProperty;
 
 import java.util.stream.Stream;
 
@@ -31,6 +35,12 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.jreleaser.util.StringUtils.isNotBlank;
 
 class EnvTests {
+    @BeforeEach
+    @AfterEach
+    void reset() {
+        Env.setOverride(false);
+    }
+
     @ParameterizedTest
     @MethodSource("variable_factory")
     @ReadsEnvironmentVariable
@@ -60,5 +70,44 @@ class EnvTests {
             Arguments.of("foobar-sys", "foo.bar", null, true),
             Arguments.of("foobar-env", "foo.bar", null, false)
         );
+    }
+
+    @Test
+    @ReadsEnvironmentVariable
+    @SetEnvironmentVariable(key = "JRELEASER_FOO", value = "foo-env")
+    @ClearSystemProperty(key = "jreleaser.foo")
+    void testEnvVariableOverridesExplicitValue() {
+        // given:
+        Env.setOverride(true);
+
+        // expect:
+        assertThat(Env.resolve("foo", "value"), equalTo("foo-env"));
+        assertThat(Env.env("foo", "value"), equalTo("foo-env"));
+    }
+
+    @Test
+    @ReadsEnvironmentVariable
+    @SetEnvironmentVariable(key = "JRELEASER_FOO", value = "foo-env")
+    @SetSystemProperty(key = "jreleaser.foo", value = "foo-sys")
+    void testSystemPropertyWinsOverEnvVariableWhenOverriding() {
+        // given:
+        Env.setOverride(true);
+
+        // expect:
+        assertThat(Env.resolve("foo", "value"), equalTo("foo-sys"));
+        assertThat(Env.sys("foo", "value"), equalTo("foo-sys"));
+    }
+
+    @Test
+    @ReadsEnvironmentVariable
+    @ClearSystemProperty(key = "jreleaser.bar")
+    void testExplicitValueSurvivesWhenNothingIsSet() {
+        // given:
+        Env.setOverride(true);
+
+        // expect:
+        assertThat(Env.resolve("bar", "value"), equalTo("value"));
+        assertThat(Env.env("bar", "value"), equalTo("value"));
+        assertThat(Env.sys("bar", "value"), equalTo("value"));
     }
 }

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/JReleaserContext.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/JReleaserContext.java
@@ -460,6 +460,7 @@ public class JReleaserContext {
         this.mode = mode;
         this.command = command;
         this.model = model;
+        this.model.getEnvironment().initOverride();
         this.basedir = basedir;
         this.settings = settings;
         this.outputDirectory = outputDirectory;

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/environment/Environment.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/environment/Environment.java
@@ -33,6 +33,7 @@ import java.io.Serializable;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -46,6 +47,7 @@ import static java.util.Collections.unmodifiableMap;
 import static org.jreleaser.model.Constants.DEFAULT_GIT_REMOTE;
 import static org.jreleaser.model.Constants.JRELEASER_USER_HOME;
 import static org.jreleaser.model.Constants.XDG_CONFIG_HOME;
+import static org.jreleaser.model.api.environment.Environment.ENVIRONMENT_OVERRIDE;
 import static org.jreleaser.util.Env.JRELEASER_ENV_PREFIX;
 import static org.jreleaser.util.Env.JRELEASER_SYS_PREFIX;
 import static org.jreleaser.util.Env.envKey;
@@ -66,6 +68,7 @@ public final class Environment extends AbstractModelObject<Environment> implemen
     @JsonIgnore
     private PropertiesSource propertiesSource;
     private String variables;
+    private Boolean override;
     @JsonIgnore
     private Properties vars;
     @JsonIgnore
@@ -86,6 +89,11 @@ public final class Environment extends AbstractModelObject<Environment> implemen
         }
 
         @Override
+        public boolean isOverride() {
+            return Environment.this.isOverride();
+        }
+
+        @Override
         public Map<String, Object> getProperties() {
             return unmodifiableMap(properties);
         }
@@ -103,28 +111,48 @@ public final class Environment extends AbstractModelObject<Environment> implemen
     @Override
     public void merge(Environment source) {
         this.variables = merge(this.variables, source.variables);
+        this.override = merge(this.override, source.override);
         setProperties(merge(this.properties, source.properties));
         setPropertiesSource(merge(this.propertiesSource, source.propertiesSource));
     }
 
-    public String resolve(String key) {
-        return env(key, Env.sys(key, ""));
+    public String resolve(String key, String value) {
+        if (isOverride()) {
+            String result = external(key);
+            return isNotBlank(result) ? result : value;
+        }
+
+        if (isNotBlank(value)) return value;
+        return external(key);
     }
 
-    public String resolve(String key, String value) {
-        return env(key, Env.sys(key, value));
+    public String resolve(Collection<String> keys, String value) {
+        if (isOverride()) {
+            String result = external(keys);
+            return isNotBlank(result) ? result : value;
+        }
+
+        if (isNotBlank(value)) return value;
+        return external(keys);
     }
 
     public String resolveOrDefault(String key, String value, String defaultValue) {
-        String result = env(key, Env.sys(key, value));
+        String result = resolve(key, value);
         return isNotBlank(result) ? result : defaultValue;
     }
 
-    private String env(String key, String value) {
-        if (isNotBlank(value)) {
-            return value;
-        }
-        return getVariable(envKey(key));
+    public String resolveOrDefault(Collection<String> keys, String value, String defaultValue) {
+        String result = resolve(keys, value);
+        return isNotBlank(result) ? result : defaultValue;
+    }
+
+    private String external(String key) {
+        String result = System.getProperty(Env.sysKey(key));
+        return isNotBlank(result) ? result : getVariable(key);
+    }
+
+    private String external(Collection<String> keys) {
+        return null != vars ? Env.resolve(keys, vars) : null;
     }
 
     public Properties getVars() {
@@ -132,12 +160,21 @@ public final class Environment extends AbstractModelObject<Environment> implemen
     }
 
     public String getVariable(String key) {
-        return vars.getProperty(Env.envKey(key));
+        return null != vars ? vars.getProperty(Env.envKey(key)) : null;
     }
 
     public boolean isSet() {
         return isNotBlank(variables) ||
+            null != override ||
             !properties.isEmpty();
+    }
+
+    public boolean isOverride() {
+        return null != override && override;
+    }
+
+    public void setOverride(Boolean override) {
+        this.override = override;
     }
 
     public PropertiesSource getPropertiesSource() {
@@ -179,6 +216,7 @@ public final class Environment extends AbstractModelObject<Environment> implemen
     public Map<String, Object> asMap(boolean full) {
         Map<String, Object> map = new LinkedHashMap<>();
         map.put("variables", variables);
+        map.put("override", override);
         map.put("properties", properties);
 
         return map;
@@ -247,7 +285,20 @@ public final class Environment extends AbstractModelObject<Environment> implemen
             if (null != propertiesSource) {
                 sourcedProperties.putAll(propertiesSource.getProperties());
             }
+
+            if (isOverride()) {
+                context.getLogger().info(RB.$("environment.override.enabled"));
+            }
         }
+    }
+
+    public void initOverride() {
+        if (null == override) {
+            String value = Env.resolve(ENVIRONMENT_OVERRIDE, "");
+            if (isNotBlank(value)) override = Boolean.parseBoolean(value);
+        }
+
+        Env.setOverride(isOverride());
     }
 
     private void loadSettings(JReleaserContext context) {

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/common/Validator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/common/Validator.java
@@ -40,6 +40,7 @@ import org.jreleaser.util.Errors;
 import java.util.Collection;
 import java.util.List;
 
+import static java.util.Collections.singletonList;
 import static org.jreleaser.model.internal.validation.common.ExtraPropertiesValidator.mergeExtraProperties;
 import static org.jreleaser.util.CollectionUtils.listOf;
 import static org.jreleaser.util.Env.check;
@@ -70,113 +71,73 @@ public final class Validator {
     }
 
     public static String checkProperty(JReleaserContext context, String key, String property, String value, Errors errors) {
-        if (isNotBlank(value)) return value;
-        Environment environment = context.getModel().getEnvironment();
-        String dsl = context.getConfigurer().toString();
-        String configFilePath = environment.getPropertiesFile().toAbsolutePath().normalize().toString();
-        return check(key, environment.resolve(key), property, dsl, configFilePath, errors);
+        return checkProperty(context, key, property, value, errors, false);
     }
 
     public static String checkProperty(JReleaserContext context, String key, String property, String value, Errors errors, boolean dryrun) {
-        if (isNotBlank(value)) return value;
         Environment environment = context.getModel().getEnvironment();
-        String dsl = context.getConfigurer().toString();
-        String configFilePath = environment.getPropertiesFile().toAbsolutePath().normalize().toString();
-        return check(key, environment.resolve(key), property, dsl, configFilePath, dryrun ? new Errors() : errors);
+        String resolved = environment.resolve(key, value);
+        if (isNotBlank(resolved)) return resolved;
+        return check(key, resolved, property, context.getConfigurer().toString(),
+            configFilePath(environment), dryrun ? new Errors() : errors);
     }
 
     public static Integer checkProperty(JReleaserContext context, String key, String property, Integer value, Errors errors, boolean dryrun) {
-        if (null != value) return value;
-        Environment environment = context.getModel().getEnvironment();
-        String dsl = context.getConfigurer().toString();
-        String configFilePath = environment.getPropertiesFile().toAbsolutePath().normalize().toString();
-        String val = check(key, environment.resolve(key), property, dsl, configFilePath, dryrun ? new Errors() : errors);
-        return isNotBlank(val) ? Integer.parseInt(val) : null;
+        String resolved = checkProperty(context, key, property, toString(value), errors, dryrun);
+        return isNotBlank(resolved) ? Integer.parseInt(resolved) : null;
     }
 
     public static String checkProperty(JReleaserContext context, String key, String property, String value, String defaultValue) {
-        if (isNotBlank(value)) return value;
-        Environment environment = context.getModel().getEnvironment();
-        String dsl = context.getConfigurer().toString();
-        String configFilePath = environment.getPropertiesFile().toAbsolutePath().normalize().toString();
-        Errors errors = new Errors();
-        String result = check(key, environment.resolve(key), property, dsl, configFilePath, errors);
-        return !errors.hasErrors() ? result : defaultValue;
+        return context.getModel().getEnvironment().resolveOrDefault(key, value, defaultValue);
     }
 
     public static boolean checkProperty(JReleaserContext context, String key, String property, Boolean value, boolean defaultValue) {
-        if (null != value) return value;
-        Environment environment = context.getModel().getEnvironment();
-        String dsl = context.getConfigurer().toString();
-        String configFilePath = environment.getPropertiesFile().toAbsolutePath().normalize().toString();
-        Errors errors = new Errors();
-        String result = check(key, environment.resolve(key), property, dsl, configFilePath, errors);
-        return !errors.hasErrors() ? Boolean.parseBoolean(result) : defaultValue;
+        return Boolean.parseBoolean(checkProperty(context, key, property, toString(value), String.valueOf(defaultValue)));
     }
 
     public static <T extends Enum<T>> String checkProperty(JReleaserContext context, String key, String property, T value, T defaultValue) {
-        if (null != value) return value.name();
-        Environment environment = context.getModel().getEnvironment();
-        String dsl = context.getConfigurer().toString();
-        String configFilePath = environment.getPropertiesFile().toAbsolutePath().normalize().toString();
-        Errors errors = new Errors();
-        String result = check(key, environment.resolve(key), property, dsl, configFilePath, errors);
-        return !errors.hasErrors() ? result : (null != defaultValue ? defaultValue.name() : null);
+        return checkProperty(context, key, property, name(value), name(defaultValue));
     }
 
     public static String checkProperty(JReleaserContext context, Collection<String> keys, String property, String value, Errors errors) {
-        if (isNotBlank(value)) return value;
-        Environment environment = context.getModel().getEnvironment();
-        String dsl = context.getConfigurer().toString();
-        String configFilePath = environment.getPropertiesFile().toAbsolutePath().normalize().toString();
-        return check(keys, environment.getVars(), property, dsl, configFilePath, errors);
+        return checkProperty(context, keys, property, value, errors, false);
     }
 
     public static String checkProperty(JReleaserContext context, Collection<String> keys, String property, String value, Errors errors, boolean dryrun) {
-        if (isNotBlank(value)) return value;
         Environment environment = context.getModel().getEnvironment();
-        String dsl = context.getConfigurer().toString();
-        String configFilePath = environment.getPropertiesFile().toAbsolutePath().normalize().toString();
-        return check(keys, environment.getVars(), property, dsl, configFilePath, dryrun ? new Errors() : errors);
+        String resolved = environment.resolve(keys, value);
+        if (isNotBlank(resolved)) return resolved;
+        return check(keys, resolved, property, context.getConfigurer().toString(),
+            configFilePath(environment), dryrun ? new Errors() : errors);
     }
 
     public static Integer checkProperty(JReleaserContext context, Collection<String> keys, String property, Integer value, Errors errors, boolean dryrun) {
-        if (null != value) return value;
-        Environment environment = context.getModel().getEnvironment();
-        String dsl = context.getConfigurer().toString();
-        String configFilePath = environment.getPropertiesFile().toAbsolutePath().normalize().toString();
-        String val = check(keys, environment.getVars(), property, dsl, configFilePath, dryrun ? new Errors() : errors);
-        return isNotBlank(val) ? Integer.parseInt(val) : null;
+        String resolved = checkProperty(context, keys, property, toString(value), errors, dryrun);
+        return isNotBlank(resolved) ? Integer.parseInt(resolved) : null;
     }
 
     public static String checkProperty(JReleaserContext context, Collection<String> keys, String property, String value, String defaultValue) {
-        if (isNotBlank(value)) return value;
-        Environment environment = context.getModel().getEnvironment();
-        String dsl = context.getConfigurer().toString();
-        String configFilePath = environment.getPropertiesFile().toAbsolutePath().normalize().toString();
-        Errors errors = new Errors();
-        String result = check(keys, environment.getVars(), property, dsl, configFilePath, errors);
-        return !errors.hasErrors() ? result : defaultValue;
+        return context.getModel().getEnvironment().resolveOrDefault(keys, value, defaultValue);
     }
 
     public static boolean checkProperty(JReleaserContext context, Collection<String> keys, String property, Boolean value, boolean defaultValue) {
-        if (null != value) return value;
-        Environment environment = context.getModel().getEnvironment();
-        String dsl = context.getConfigurer().toString();
-        String configFilePath = environment.getPropertiesFile().toAbsolutePath().normalize().toString();
-        Errors errors = new Errors();
-        String result = check(keys, environment.getVars(), property, dsl, configFilePath, errors);
-        return !errors.hasErrors() ? Boolean.parseBoolean(result) : defaultValue;
+        return Boolean.parseBoolean(checkProperty(context, keys, property, toString(value), String.valueOf(defaultValue)));
     }
 
     public static <T extends Enum<T>> String checkProperty(JReleaserContext context, Collection<String> keys, String property, T value, T defaultValue) {
-        if (null != value) return value.name();
-        Environment environment = context.getModel().getEnvironment();
-        String dsl = context.getConfigurer().toString();
-        String configFilePath = environment.getPropertiesFile().toAbsolutePath().normalize().toString();
-        Errors errors = new Errors();
-        String result = check(keys, environment.getVars(), property, dsl, configFilePath, errors);
-        return !errors.hasErrors() ? result : (null != defaultValue ? defaultValue.name() : null);
+        return checkProperty(context, keys, property, name(value), name(defaultValue));
+    }
+
+    private static String configFilePath(Environment environment) {
+        return environment.getPropertiesFile().toAbsolutePath().normalize().toString();
+    }
+
+    private static String toString(Object value) {
+        return null != value ? String.valueOf(value) : "";
+    }
+
+    private static <T extends Enum<T>> String name(T value) {
+        return null != value ? value.name() : null;
     }
 
     public static void validateOwner(OwnerAware self, OwnerAware other) {
@@ -374,36 +335,36 @@ public final class Validator {
     }
 
     public static void resolveActivatable(JReleaserContext context, Activatable activatable, String key, Activatable parentActivatable) {
-        if (!activatable.isActiveSet()) {
-            String value = context.getModel().getEnvironment().resolve(key + ".active", "");
-            // defaultValue may be blank
-            if (isNotBlank(value)) {
-                activatable.setActive(value);
-            } else {
-                activatable.setActive(parentActivatable.getActive());
-            }
+        String value = resolveActive(context, activatable, singletonList(key));
+        // defaultValue may be blank
+        if (isNotBlank(value)) {
+            activatable.setActive(value);
+        } else {
+            activatable.setActive(parentActivatable.getActive());
         }
     }
 
     public static void resolveActivatable(JReleaserContext context, Activatable activatable, String key, String defaultValue) {
-        if (!activatable.isActiveSet()) {
-            String value = context.getModel().getEnvironment().resolveOrDefault(key + ".active", "", defaultValue);
-            // defaultValue may be blank
-            if (isNotBlank(value)) activatable.setActive(value);
-        }
+        resolveActivatable(context, activatable, singletonList(key), defaultValue);
     }
 
     public static void resolveActivatable(JReleaserContext context, Activatable activatable, List<String> keys, String defaultValue) {
-        if (!activatable.isActiveSet()) {
-            String value = null;
-            for (String key : keys) {
-                value = context.getModel().getEnvironment().resolve(key + ".active", "");
-                if (isNotBlank(value)) break;
-            }
+        String value = resolveActive(context, activatable, keys);
+        // defaultValue may be blank
+        value = isNotBlank(value) ? value : defaultValue;
+        if (isNotBlank(value)) activatable.setActive(value);
+    }
 
-            // defaultValue may be blank
-            value = isNotBlank(value) ? value : defaultValue;
-            if (isNotBlank(value)) activatable.setActive(value);
+    private static String resolveActive(JReleaserContext context, Activatable activatable, List<String> keys) {
+        Environment environment = context.getModel().getEnvironment();
+        String current = null != activatable.getActive() ? activatable.getActive().name() : "";
+        if (!environment.isOverride() && isNotBlank(current)) return current;
+
+        for (String key : keys) {
+            String value = environment.resolve(key + ".active", "");
+            if (isNotBlank(value)) return value;
         }
+
+        return current;
     }
 }

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/release/BaseReleaserValidator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/release/BaseReleaserValidator.java
@@ -146,47 +146,40 @@ public final class BaseReleaserValidator {
                 service.getBranchPush(),
                 service.getBranch()));
 
-        if (!service.isOverwriteSet()) {
-            service.setOverwrite(
-                checkProperty(context,
-                    OVERWRITE,
-                    baseKey + "overwrite",
-                    null,
-                    false));
-        }
+        service.setOverwrite(
+            checkProperty(context,
+                OVERWRITE,
+                baseKey + "overwrite",
+                service.isOverwriteSet() ? service.isOverwrite() : null,
+                false));
 
         if (service.isReleaseSupported()) {
-            if (!service.getUpdate().isEnabledSet()) {
-                service.getUpdate().setEnabled(
-                    checkProperty(context,
-                        UPDATE,
-                        baseKey + "update",
-                        null,
-                        false));
-            }
-
-            if (service.getUpdate().isEnabled() && service.getUpdate().getSections().isEmpty()) {
-                service.getUpdate().getSections().add(UpdateSection.ASSETS);
-            }
-        }
-
-        if (!service.isSkipTagSet()) {
-            service.setSkipTag(
+            BaseReleaser.Update update = service.getUpdate();
+            update.setEnabled(
                 checkProperty(context,
-                    SKIP_TAG,
-                    baseKey + "skipTag",
-                    null,
+                    UPDATE,
+                    baseKey + "update",
+                    update.isEnabledSet() ? update.isEnabled() : null,
                     false));
+
+            if (update.isEnabled() && update.getSections().isEmpty()) {
+                update.getSections().add(UpdateSection.ASSETS);
+            }
         }
 
-        if (!service.isSkipReleaseSet()) {
-            service.setSkipRelease(
-                checkProperty(context,
-                    SKIP_RELEASE,
-                    baseKey + "skipRelease",
-                    null,
-                    false));
-        }
+        service.setSkipTag(
+            checkProperty(context,
+                SKIP_TAG,
+                baseKey + "skipTag",
+                service.isSkipTagSet() ? service.isSkipTag() : null,
+                false));
+
+        service.setSkipRelease(
+            checkProperty(context,
+                SKIP_RELEASE,
+                baseKey + "skipRelease",
+                service.isSkipReleaseSet() ? service.isSkipRelease() : null,
+                false));
 
         if (isBlank(service.getTagName())) {
             service.setTagName("v" + project.getVersion());

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/release/CodebergReleaserValidator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/release/CodebergReleaserValidator.java
@@ -55,14 +55,12 @@ public final class CodebergReleaserValidator {
                 ""));
         service.getPrerelease().isPrerelease(context.getModel().getProject().getResolvedVersion());
 
-        if (!service.isDraftSet()) {
-            service.setDraft(
-                checkProperty(context,
-                    DRAFT,
-                    "release.codeberg.draft",
-                    null,
-                    false));
-        }
+        service.setDraft(
+            checkProperty(context,
+                DRAFT,
+                "release.codeberg.draft",
+                service.isDraftSet() ? service.isDraft() : null,
+                false));
 
         if (service.isDraft()) {
             service.getMilestone().setClose(false);

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/release/ForgejoReleaserValidator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/release/ForgejoReleaserValidator.java
@@ -60,14 +60,12 @@ public final class ForgejoReleaserValidator {
                 ""));
         service.getPrerelease().isPrerelease(context.getModel().getProject().getResolvedVersion());
 
-        if (!service.isDraftSet()) {
-            service.setDraft(
-                checkProperty(context,
-                    DRAFT,
-                    "release.forgejo.draft",
-                    null,
-                    false));
-        }
+        service.setDraft(
+            checkProperty(context,
+                DRAFT,
+                "release.forgejo.draft",
+                service.isDraftSet() ? service.isDraft() : null,
+                false));
 
         if (!service.getUpdate().isEnabled()) {
             if (!service.getPrerelease().isEnabledSet()) {

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/release/GiteaReleaserValidator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/release/GiteaReleaserValidator.java
@@ -60,14 +60,12 @@ public final class GiteaReleaserValidator {
                 ""));
         service.getPrerelease().isPrerelease(context.getModel().getProject().getResolvedVersion());
 
-        if (!service.isDraftSet()) {
-            service.setDraft(
-                checkProperty(context,
-                    DRAFT,
-                    "release.gitea.draft",
-                    null,
-                    false));
-        }
+        service.setDraft(
+            checkProperty(context,
+                DRAFT,
+                "release.gitea.draft",
+                service.isDraftSet() ? service.isDraft() : null,
+                false));
 
         if (!service.getUpdate().isEnabled()) {
             if (!service.getPrerelease().isEnabledSet()) {

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/release/GithubReleaserValidator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/release/GithubReleaserValidator.java
@@ -62,14 +62,12 @@ public final class GithubReleaserValidator {
                 service.getMakeLatest(),
                 org.jreleaser.model.api.release.GithubReleaser.MakeLatest.TRUE));
 
-        if (!service.isDraftSet()) {
-            service.setDraft(
-                checkProperty(context,
-                    DRAFT,
-                    "release.github.draft",
-                    null,
-                    false));
-        }
+        service.setDraft(
+            checkProperty(context,
+                DRAFT,
+                "release.github.draft",
+                service.isDraftSet() ? service.isDraft() : null,
+                false));
 
         if (!service.getUpdate().isEnabled()) {
             if (!service.getPrerelease().isEnabledSet()) {

--- a/core/jreleaser-model-impl/src/test/java/org/jreleaser/model/internal/environment/EnvironmentOverrideTest.java
+++ b/core/jreleaser-model-impl/src/test/java/org/jreleaser/model/internal/environment/EnvironmentOverrideTest.java
@@ -1,0 +1,162 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2026 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.model.internal.environment;
+
+import org.jreleaser.logging.SimpleJReleaserLoggerAdapter;
+import org.jreleaser.model.Active;
+import org.jreleaser.model.api.JReleaserCommand;
+import org.jreleaser.model.api.JReleaserContext.Mode;
+import org.jreleaser.model.internal.JReleaserContext;
+import org.jreleaser.model.internal.JReleaserModel;
+import org.jreleaser.model.internal.signing.Signing;
+import org.jreleaser.util.Env;
+import org.jreleaser.util.Errors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import static org.jreleaser.model.internal.validation.common.Validator.checkProperty;
+import static org.jreleaser.model.internal.validation.common.Validator.resolveActivatable;
+import static org.jreleaser.util.CollectionUtils.listOf;
+import static org.jreleaser.util.StringUtils.isNotBlank;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @since 1.26.0
+ */
+class EnvironmentOverrideTest {
+    private static final String KEY = "ENVIRONMENT_OVERRIDE_TEST";
+    private static final String ALT_KEY = "ENVIRONMENT_OVERRIDE_TEST_ALT";
+    private static final String SYS_KEY = Env.sysKey(KEY);
+    private static final String ALT_SYS_KEY = Env.sysKey(ALT_KEY);
+    private static final String SIGNING_SYS_KEY = Env.sysKey("signing.active");
+    private static final String OVERRIDE_SYS_KEY = Env.sysKey(org.jreleaser.model.api.environment.Environment.ENVIRONMENT_OVERRIDE);
+
+    @BeforeEach
+    @AfterEach
+    void reset() {
+        System.clearProperty(SYS_KEY);
+        System.clearProperty(ALT_SYS_KEY);
+        System.clearProperty(SIGNING_SYS_KEY);
+        System.clearProperty(OVERRIDE_SYS_KEY);
+        Env.setOverride(false);
+    }
+
+    @ParameterizedTest
+    @MethodSource("property_factory")
+    void testPropertyResolution(String expected, Boolean override, String overrideSysProp, String sysProp, @TempDir Path tempDir) {
+        // given:
+        if (isNotBlank(overrideSysProp)) System.setProperty(OVERRIDE_SYS_KEY, overrideSysProp);
+        if (isNotBlank(sysProp)) System.setProperty(SYS_KEY, sysProp);
+        JReleaserContext context = createContext(tempDir, override);
+        Errors errors = new Errors();
+
+        // expect:
+        assertEquals(null != override ? override : "true".equals(overrideSysProp),
+            context.getModel().getEnvironment().isOverride());
+        assertEquals(expected, checkProperty(context, KEY, "test", "from-dsl", errors));
+    }
+
+    private static Stream<Arguments> property_factory() {
+        return Stream.of(
+            Arguments.of("from-dsl", false, null, "from-sysprop"),
+            Arguments.of("from-sysprop", true, null, "from-sysprop"),
+            Arguments.of("from-dsl", true, null, null),
+            Arguments.of("from-sysprop", null, "true", "from-sysprop"),
+            Arguments.of("from-dsl", false, "true", "from-sysprop")
+        );
+    }
+
+    @Test
+    void sysPropWinsWhenOverrideIsEnabledForMultipleKeys(@TempDir Path tempDir) {
+        // given:
+        System.setProperty(ALT_SYS_KEY, "from-sysprop");
+        JReleaserContext context = createContext(tempDir, true);
+        Errors errors = new Errors();
+
+        // expect:
+        assertEquals("from-sysprop", checkProperty(context, listOf(KEY, ALT_KEY), "test", "from-dsl", errors));
+        assertTrue(Env.isOverride());
+    }
+
+    @Test
+    void explicitValueSurvivesWhenNothingIsSetExternallyForMultipleKeys(@TempDir Path tempDir) {
+        // given:
+        JReleaserContext context = createContext(tempDir, true);
+        Errors errors = new Errors();
+
+        // expect:
+        assertEquals("from-dsl", checkProperty(context, listOf(KEY, ALT_KEY), "test", "from-dsl", errors));
+    }
+
+    @ParameterizedTest
+    @MethodSource("active_factory")
+    void testActiveResolution(Active expected, Boolean override, @TempDir Path tempDir) {
+        // given:
+        System.setProperty(SIGNING_SYS_KEY, "NEVER");
+        JReleaserContext context = createContext(tempDir, override);
+        Signing signing = context.getModel().getSigning();
+        signing.setActive(Active.ALWAYS);
+
+        // when:
+        resolveActivatable(context, signing, "signing", "ALWAYS");
+
+        // then:
+        assertEquals(expected, signing.getActive());
+    }
+
+    private static Stream<Arguments> active_factory() {
+        return Stream.of(
+            Arguments.of(Active.NEVER, true),
+            Arguments.of(Active.ALWAYS, false)
+        );
+    }
+
+    private static JReleaserContext createContext(Path basedir, Boolean override) {
+        JReleaserModel model = new JReleaserModel();
+        model.getEnvironment().setOverride(override);
+
+        JReleaserContext context = new JReleaserContext(
+            new SimpleJReleaserLoggerAdapter(SimpleJReleaserLoggerAdapter.Level.WARN),
+            JReleaserContext.Configurer.CLI_YAML,
+            Mode.FULL,
+            JReleaserCommand.FULL_RELEASE,
+            model,
+            basedir,
+            basedir.resolve("settings.properties"),
+            basedir.resolve("out/jreleaser"),
+            false,
+            true,
+            true,
+            false,
+            false,
+            Collections.emptyList(),
+            Collections.emptyList());
+        context.getModel().getEnvironment().initProps(context);
+        return context;
+    }
+}

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/dsl/environment/Environment.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/dsl/environment/Environment.groovy
@@ -20,6 +20,7 @@ package org.jreleaser.gradle.plugin.dsl.environment
 import groovy.transform.CompileStatic
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
 
 /**
  *
@@ -31,6 +32,8 @@ interface Environment {
     RegularFileProperty getVariables()
 
     void setVariables(String variables)
+
+    Property<Boolean> getOverride()
 
     MapProperty<String, Object> getProperties()
 }

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/environment/EnvironmentImpl.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/dsl/environment/EnvironmentImpl.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.internal.provider.Providers
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.jreleaser.gradle.plugin.dsl.environment.Environment
 import org.jreleaser.gradle.plugin.internal.JReleaserGradleProjectCapture
@@ -36,11 +37,13 @@ import javax.inject.Inject
 @CompileStatic
 class EnvironmentImpl implements Environment {
     final RegularFileProperty variables
+    final Property<Boolean> override
     final MapProperty<String, Object> properties
 
     @Inject
     EnvironmentImpl(ObjectFactory objects) {
         variables = objects.fileProperty().convention(Providers.notDefined())
+        override = objects.property(Boolean).convention(Providers.<Boolean> notDefined())
         properties = objects.mapProperty(String, Object).convention(Providers.notDefined())
     }
 
@@ -54,6 +57,7 @@ class EnvironmentImpl implements Environment {
         environment.propertiesSource = new org.jreleaser.model.internal.environment.Environment.MapPropertiesSource(
             filterProperties(gradleProjectCapture.properties))
         if (variables.present) environment.variables = variables.asFile.get().absolutePath
+        if (override.present) environment.override = override.get()
         if (properties.present) environment.properties.putAll(properties.get())
         environment
     }


### PR DESCRIPTION
Fixes #2133

### Context
Add an environment.override flag. When enabled, environment variables and system properties take precedence over values explicitly set in the DSL. System properties keep winning over environment variables.

The flag can also be turned on without touching the config file by setting JRELEASER_ENVIRONMENT_OVERRIDE or jreleaser.environment.override.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/.github/blob/main/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
         https://github.com/jreleaser/jreleaser.github.io/pull/110
