### PR TITLE
fix(gradle): Do not resolve the logger service during the configuration phase

### DIFF
--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/JReleaserGradleProjectCapture.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/JReleaserGradleProjectCapture.groovy
@@ -18,10 +18,10 @@
 package org.jreleaser.gradle.plugin.internal
 
 import org.gradle.api.Project
+import org.gradle.api.logging.Logger
 import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.api.plugins.JavaApplication
 import org.gradle.api.provider.Provider
-import org.jreleaser.logging.JReleaserLogger
 
 /**
  * Captures relevant information from a Gradle Project
@@ -70,11 +70,14 @@ class JReleaserGradleProjectCapture implements Serializable {
         'testResultsDirName'
     ]
 
-    static JReleaserGradleProjectCapture of(Project gradleProject, JReleaserLogger logger) {
+    // Takes the Gradle logger rather than the JReleaserLogger on purpose: the capture happens at
+    // configuration time, and resolving the JReleaserLoggerService here would open build/jreleaser/trace.log
+    // before Gradle gets a chance to clean that directory as a stale task output.
+    static JReleaserGradleProjectCapture of(Project gradleProject, Logger logger) {
         return new JReleaserGradleProjectCapture(gradleProject, logger)
     }
 
-    private JReleaserGradleProjectCapture(Project gradleProject, JReleaserLogger logger) {
+    private JReleaserGradleProjectCapture(Project gradleProject, Logger logger) {
         this.name = gradleProject.name
         this.group = gradleProject.group?.toString()
         this.version = gradleProject.version?.toString()
@@ -87,7 +90,7 @@ class JReleaserGradleProjectCapture implements Serializable {
     }
 
     private static Map <String, Serializable> captureGradleProjectSerializableProperties(
-        Project gradleProject, JReleaserLogger logger) {
+        Project gradleProject, Logger logger) {
         Set<String> propertyKeys = collectGradleProjectPropertyKeys(gradleProject)
         Map <String, Serializable> projectProperties = [:]
         propertyKeys.each { key ->

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/AbstractJReleaserDefaultTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/AbstractJReleaserDefaultTask.groovy
@@ -70,7 +70,7 @@ abstract class AbstractJReleaserDefaultTask extends DefaultTask {
             = JReleaserProjectConfigurer.getJReleaserLoggerServiceProvider(project)
         jlogger.convention(jloggerServiceProvider)
         usesService(jloggerServiceProvider)
-        gradleProjectCapture.convention(JReleaserGradleProjectCapture.of(project, jlogger.get().logger))
+        gradleProjectCapture.convention(JReleaserGradleProjectCapture.of(project, logger))
         projectDirectory.convention(project.layout.projectDirectory)
         outputDirectory.convention(JReleaserProjectConfigurer.getJReleaserOutputDirectoryProvider(project))
     }


### PR DESCRIPTION
Addresses one of the two failures reported in #2150.

### Context

Issue #2150 reports two independent failures from a single `gradlew jreleaserConfig` run.
This change fixes the first of them:

    Unable to delete directory '...\build\jreleaser'
    Failed to delete some children. This might happen because a process has files open
    or has its working directory set in the target directory.
    - ...\build\jreleaser\trace.log

The constructor of `AbstractJReleaserDefaultTask` resolved `JReleaserLoggerService` while
the task was being configured, only to obtain a logger for the debug output of
`JReleaserGradleProjectCapture`. Constructing that service opens
`build/jreleaser/trace.log`, and because `build/jreleaser` is the `@OutputDirectory` of
every JReleaser task, Gradle's stale output cleanup then tries to delete that directory
before running the task. On Windows the open file handle makes the deletion fail, so the
task cannot run.

The failure is not limited to the first build. The task never completes, so Gradle never
records the output directory and repeats the cleanup on every later build.

- `JReleaserGradleProjectCapture.groovy`: take the Gradle `Logger` instead of the
  `JReleaserLogger`, so capturing the project properties no longer needs the build service
- `AbstractJReleaserDefaultTask.groovy`: pass the task logger to
  `JReleaserGradleProjectCapture.of`

The build service is now created on first use inside the task action, after Gradle has
cleaned the output directory.

Closed issue #1074 covered the same open-handle mechanism, but only for the `clean` task,
which was addressed with a `doFirst` hook that closes the logger. That hook does not cover
Gradle's stale output cleanup of the `@OutputDirectory`.

### Verification

Sample single-project build on Windows, JDK 21.

On Gradle 9.6.1, the version reported in #2150: before this change `gradlew jreleaserConfig`
fails with the message above, and with `-Dorg.gradle.unsafe.isolated-projects=true` both of
#2150's failures appear together. After this change the delete failure is gone and only the
`Project.getProperties()` problem remains.

On Gradle 8.14.3: before this change `gradlew jreleaserChecksum` and
`gradlew jreleaserChecksum jreleaserConfig` both fail with the same delete error. After it,
both succeed.

### Follow-ups

Three further Gradle plugin fixes follow this one, each as its own pull request:

- Issue #771, configuration cache support. `JReleaserConfigTask` invokes `Task.project` at
  execution time, which the configuration cache does not allow.
- Issue #2145, `trace.log` not always written. The shared logger is closed several times
  during a build, and a closed `PrintWriter` silently swallows everything traced afterwards.
- Issue #2150, the remaining half of this report. `Project.getProperties()` is not allowed
  with Isolated Projects.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/.github/blob/main/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable. — internal fix, no user-facing change
