### PR TITLE
fix(gradle): Support the configuration cache

### DIFF
--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/GradleJReleaserModelPrinter.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/GradleJReleaserModelPrinter.groovy
@@ -18,7 +18,6 @@
 package org.jreleaser.gradle.plugin.internal
 
 import groovy.transform.CompileStatic
-import org.gradle.api.Project
 import org.jreleaser.model.internal.JReleaserModelPrinter
 import org.kordamp.gradle.util.AnsiConsole
 
@@ -32,13 +31,13 @@ import static org.jreleaser.util.IoUtils.newPrintWriter
 class GradleJReleaserModelPrinter extends JReleaserModelPrinter {
     private final AnsiConsole console
 
-    GradleJReleaserModelPrinter(Project project) {
-        this(project, newPrintWriter(System.out))
+    GradleJReleaserModelPrinter(AnsiConsole console) {
+        this(console, newPrintWriter(System.out))
     }
 
-    GradleJReleaserModelPrinter(Project project, PrintWriter out) {
+    GradleJReleaserModelPrinter(AnsiConsole console, PrintWriter out) {
         super(out)
-        this.console = new AnsiConsole(project, 'JRELEASER')
+        this.console = console
     }
 
     @Override

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/JReleaserLoggerService.java
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/internal/JReleaserLoggerService.java
@@ -39,6 +39,7 @@ import java.nio.file.Path;
  */
 public abstract class JReleaserLoggerService implements BuildService<JReleaserLoggerService.Params>, AutoCloseable {
     private final JReleaserLogger logger;
+    private final AnsiConsole console;
 
     public interface Params extends BuildServiceParameters {
         Property<AnsiConsole> getConsole();
@@ -55,7 +56,8 @@ public abstract class JReleaserLoggerService implements BuildService<JReleaserLo
             File traceLogFile = outputDirectoryPath.resolve("trace.log").toFile();
             PrintWriter tracer = IoUtils.newPrintWriter(new FileOutputStream(traceLogFile));
 
-            logger = new JReleaserLoggerAdapter(getParameters().getConsole().get(),
+            console = getParameters().getConsole().get();
+            logger = new JReleaserLoggerAdapter(console,
                 getParameters().getLogLevel().get(), tracer);
         } catch (IOException e) {
             throw new IllegalStateException(e);
@@ -64,6 +66,10 @@ public abstract class JReleaserLoggerService implements BuildService<JReleaserLo
 
     public JReleaserLogger getLogger() {
         return logger;
+    }
+
+    public AnsiConsole getConsole() {
+        return console;
     }
 
     @Override

--- a/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserConfigTask.groovy
+++ b/plugins/jreleaser-gradle-plugin/src/main/groovy/org/jreleaser/gradle/plugin/tasks/JReleaserConfigTask.groovy
@@ -128,7 +128,7 @@ abstract class JReleaserConfigTask extends AbstractPlatformAwareJReleaserTask {
 
         JReleaserContext context = createContext()
         ModelValidator.validate(context)
-        new GradleJReleaserModelPrinter(project)
+        new GradleJReleaserModelPrinter(jlogger.get().console)
             .print(context.model.asMap(full.get()))
         context.report()
     }


### PR DESCRIPTION
Fixes #771

### Context

`JReleaserConfigTask` built its model printer with

    new GradleJReleaserModelPrinter(project)

and `Task.project` is not available at execution time once the configuration cache is
enabled:

    invocation of 'Task.project' at execution time is unsupported with the configuration cache

The printer only needs an `AnsiConsole`, and `JReleaserLoggerService` already receives one
as a build service parameter, so it can be taken from there.

- `JReleaserLoggerService.java`: keep the `AnsiConsole` from the parameters and expose it
  through `getConsole()`
- `GradleJReleaserModelPrinter.groovy`: take an `AnsiConsole` instead of a `Project`
- `JReleaserConfigTask.groovy`: build the printer from the console of the logger service

### Verification

Sample build on Windows, JDK 21, on Gradle 8.14.3 and 9.7.1.

Before this change, `gradlew --configuration-cache jreleaserConfig` fails with the message
above and the entry is discarded. After it, the entry is stored and then reused on a second
invocation.

Store-then-reuse was checked with no reported problems for `jreleaserConfig`,
`jreleaserEnv`, `jreleaserJsonSchema`, `jreleaserChangelog`, `jreleaserChecksum`,
`jreleaserCatalog`, `jreleaserAssemble`, `jreleaserPrepare`, `jreleaserPackage` and
`jreleaserSign`. The remaining tasks need credentials, a remote or distributions that the
sample project does not have.

`JReleaserConfigTask` held the only execution-time `project` access in the tasks package;
every other reference is made while the task is being configured. The plugin registers no
build or task execution listeners.

### Follow-ups

Three further Gradle plugin fixes accompany this one, each as its own pull request:

- Issue #2150, first of its two failures. Resolving the logger service while the task is
  configured opens `build/jreleaser/trace.log`, so Gradle's stale output cleanup cannot
  delete the output directory on Windows.
- Issue #2145, `trace.log` not always written. The shared logger is closed several times
  during a build, and a closed `PrintWriter` silently swallows everything traced afterwards.
- Issue #2150, second failure. `Project.getProperties()` is not allowed with Isolated
  Projects.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/.github/blob/main/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable. — internal fix, no user-facing change
