### PR TITLE
fix: Parse POMs without XPath so native-image works

### DIFF
--- a/core/jreleaser-model-impl/src/main/resources/META-INF/native-image/org.jreleaser/defaults/resource-config.json
+++ b/core/jreleaser-model-impl/src/main/resources/META-INF/native-image/org.jreleaser/defaults/resource-config.json
@@ -5,10 +5,5 @@
                 "pattern": "META-INF/jreleaser/changelog/.*.yml"
             }
         ]
-    },
-    "bundles": [
-        {
-            "name": "com.sun.org.apache.xml.internal.res.XMLErrorResources"
-        }
-    ]
+    }
 }

--- a/sdks/jreleaser-java-sdk-commons/src/main/java/org/jreleaser/sdk/commons/AbstractMavenDeployer.java
+++ b/sdks/jreleaser-java-sdk-commons/src/main/java/org/jreleaser/sdk/commons/AbstractMavenDeployer.java
@@ -39,13 +39,13 @@ import org.jreleaser.util.CollectionUtils;
 import org.jreleaser.util.Errors;
 import org.jreleaser.util.FileUtils;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactory;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
@@ -163,7 +163,7 @@ public abstract class AbstractMavenDeployer<A extends org.jreleaser.model.api.de
         }
 
         try {
-            DeployableCollector collector = new DeployableCollector(root, context.getModel().getProject().isSnapshot());
+            DeployableCollector collector = new DeployableCollector(context, root, context.getModel().getProject().isSnapshot());
 
             java.nio.file.Files.walkFileTree(root, collector);
             if (collector.failed) {
@@ -672,13 +672,15 @@ public abstract class AbstractMavenDeployer<A extends org.jreleaser.model.api.de
         // noop
     }
 
-    private class DeployableCollector extends SimpleFileVisitor<Path> {
+    static class DeployableCollector extends SimpleFileVisitor<Path> {
+        private final JReleaserContext context;
         private final Path root;
         private final Set<Deployable> deployables = new TreeSet<>();
         private final boolean projectIsSnapshot;
         private boolean failed;
 
-        public DeployableCollector(Path root, boolean projectIsSnapshot) {
+        public DeployableCollector(JReleaserContext context, Path root, boolean projectIsSnapshot) {
+            this.context = context;
             this.root = root;
             this.projectIsSnapshot = projectIsSnapshot;
         }
@@ -711,7 +713,9 @@ public abstract class AbstractMavenDeployer<A extends org.jreleaser.model.api.de
             ));
         }
 
-        private PomResult parsePom(Path artifactPath) {
+        // Walks the document with plain DOM calls. XPath reaches JDK internals that are
+        // instantiated reflectively, which does not survive a GraalVM native-image build.
+        static PomResult parsePom(Path artifactPath) {
             // only inspect if artifactPath ends with .pom
             if (artifactPath.getFileName().toString().endsWith(EXT_JAR)) return new PomResult(PACKAGING_JAR);
             if (!artifactPath.getFileName().toString().endsWith(EXT_POM)) return new PomResult("");
@@ -722,23 +726,35 @@ public abstract class AbstractMavenDeployer<A extends org.jreleaser.model.api.de
                 Document document = factory
                     .newDocumentBuilder()
                     .parse(artifactPath.toFile());
-                String query = "/project/packaging";
-                String packaging = (String) XPathFactory.newInstance()
-                    .newXPath()
-                    .compile(query)
-                    .evaluate(document, XPathConstants.STRING);
 
-                query = "/project/distributionManagement/relocation";
-                Object relocation = XPathFactory.newInstance()
-                    .newXPath()
-                    .compile(query)
-                    .evaluate(document, XPathConstants.NODE);
+                Element project = document.getDocumentElement();
+                if (!"project".equals(project.getTagName())) return new PomResult(PACKAGING_JAR);
+
+                String packaging = textOf(findChild(project, "packaging"));
+                Element relocation = findChild(findChild(project, "distributionManagement"), "relocation");
 
                 return new PomResult(isNotBlank(packaging) ? packaging.trim() : PACKAGING_JAR,
                     relocation != null);
-            } catch (ParserConfigurationException | IOException | SAXException | XPathExpressionException e) {
+            } catch (ParserConfigurationException | IOException | SAXException e) {
                 throw new IllegalStateException(e);
             }
+        }
+
+        private static Element findChild(Element parent, String tagName) {
+            if (parent == null) return null;
+
+            NodeList children = parent.getChildNodes();
+            for (int i = 0; i < children.getLength(); i++) {
+                Node child = children.item(i);
+                if (child instanceof Element && tagName.equals(((Element) child).getTagName())) {
+                    return (Element) child;
+                }
+            }
+            return null;
+        }
+
+        private static String textOf(Element element) {
+            return element != null ? element.getTextContent() : "";
         }
 
         @Override
@@ -756,9 +772,9 @@ public abstract class AbstractMavenDeployer<A extends org.jreleaser.model.api.de
             return CONTINUE;
         }
 
-        private final class PomResult {
-            private String packaging;
-            private boolean relocated;
+        static final class PomResult {
+            String packaging;
+            boolean relocated;
 
             private PomResult(String packaging) {
                 this.packaging = packaging;

--- a/sdks/jreleaser-java-sdk-commons/src/test/java/org/jreleaser/sdk/commons/AbstractMavenDeployerTest.java
+++ b/sdks/jreleaser-java-sdk-commons/src/test/java/org/jreleaser/sdk/commons/AbstractMavenDeployerTest.java
@@ -108,6 +108,24 @@ class AbstractMavenDeployerTest {
               <profiles>
                 <profile>
                   <packaging>pom</packaging>
+                </profile>
+              </profiles>
+            </project>
+            """);
+
+        var result = AbstractMavenDeployer.DeployableCollector.parsePom(path);
+
+        assertThat(result.packaging).isEqualTo("jar");
+    }
+
+    // A relocation declared in a profile is not detected. That needs a fully resolved model.
+    @Test
+    void profileScopedRelocationIsNotDetected() throws IOException {
+        var path = pom("""
+            <project xmlns="http://maven.apache.org/POM/4.0.0">
+              <artifactId>old</artifactId>
+              <profiles>
+                <profile>
                   <distributionManagement>
                     <relocation>
                       <artifactId>new</artifactId>
@@ -120,7 +138,6 @@ class AbstractMavenDeployerTest {
 
         var result = AbstractMavenDeployer.DeployableCollector.parsePom(path);
 
-        assertThat(result.packaging).isEqualTo("jar");
         assertThat(result.relocated).isFalse();
     }
 

--- a/sdks/jreleaser-java-sdk-commons/src/test/java/org/jreleaser/sdk/commons/AbstractMavenDeployerTest.java
+++ b/sdks/jreleaser-java-sdk-commons/src/test/java/org/jreleaser/sdk/commons/AbstractMavenDeployerTest.java
@@ -1,0 +1,134 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2020-2026 The JReleaser authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jreleaser.sdk.commons;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AbstractMavenDeployerTest {
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void missingPackagingDefaultsToJar() throws IOException {
+        var path = pom("""
+            <project xmlns="http://maven.apache.org/POM/4.0.0">
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>com.example</groupId>
+              <artifactId>demo</artifactId>
+              <version>1.0.0</version>
+            </project>
+            """);
+
+        var result = AbstractMavenDeployer.DeployableCollector.parsePom(path);
+
+        assertThat(result.packaging).isEqualTo("jar");
+        assertThat(result.relocated).isFalse();
+    }
+
+    @Test
+    void declaredPackagingIsRead() throws IOException {
+        var path = pom("""
+            <project xmlns="http://maven.apache.org/POM/4.0.0">
+              <artifactId>demo</artifactId>
+              <packaging>pom</packaging>
+            </project>
+            """);
+
+        var result = AbstractMavenDeployer.DeployableCollector.parsePom(path);
+
+        assertThat(result.packaging).isEqualTo("pom");
+        assertThat(result.relocated).isFalse();
+    }
+
+    @Test
+    void relocationIsDetected() throws IOException {
+        var path = pom("""
+            <project xmlns="http://maven.apache.org/POM/4.0.0">
+              <artifactId>old</artifactId>
+              <distributionManagement>
+                <relocation>
+                  <artifactId>new</artifactId>
+                </relocation>
+              </distributionManagement>
+            </project>
+            """);
+
+        var result = AbstractMavenDeployer.DeployableCollector.parsePom(path);
+
+        assertThat(result.packaging).isEqualTo("jar");
+        assertThat(result.relocated).isTrue();
+    }
+
+    @Test
+    void distributionManagementWithoutRelocationIsNotRelocated() throws IOException {
+        var path = pom("""
+            <project xmlns="http://maven.apache.org/POM/4.0.0">
+              <artifactId>demo</artifactId>
+              <distributionManagement>
+                <repository>
+                  <id>central</id>
+                </repository>
+              </distributionManagement>
+            </project>
+            """);
+
+        var result = AbstractMavenDeployer.DeployableCollector.parsePom(path);
+
+        assertThat(result.relocated).isFalse();
+    }
+
+    @Test
+    void onlyDirectChildrenOfProjectAreConsidered() throws IOException {
+        var path = pom("""
+            <project xmlns="http://maven.apache.org/POM/4.0.0">
+              <artifactId>demo</artifactId>
+              <profiles>
+                <profile>
+                  <packaging>pom</packaging>
+                  <distributionManagement>
+                    <relocation>
+                      <artifactId>new</artifactId>
+                    </relocation>
+                  </distributionManagement>
+                </profile>
+              </profiles>
+            </project>
+            """);
+
+        var result = AbstractMavenDeployer.DeployableCollector.parsePom(path);
+
+        assertThat(result.packaging).isEqualTo("jar");
+        assertThat(result.relocated).isFalse();
+    }
+
+    private Path pom(String body) throws IOException {
+        var path = tempDir.resolve("demo-1.0.0.pom");
+        Files.writeString(path, """
+            <?xml version="1.0" encoding="UTF-8"?>
+            """ + body, UTF_8);
+        return path;
+    }
+}


### PR DESCRIPTION
Fixes #2166

### Context

`PathExpression.evaluate` reaches `StringBufferPool, which builds its `FastStringBuffer` instances reflectively. That constructor is not registered for reflection, so every POM parse fails in the native distribution with "exception creating new instance for pool".

Instead of maintaining `reflect-config.json` and bloating the binary file, this PR refactors the logic with plain DOM traversal, so XPath is not needed.

For unit testing, the private members are turned into package-private and static.
I avoided extracting `PomReader` or such to minimize code diff.

#### Disclosure

LLM was involved only in investigation. 
I written code manually.

#### Bonus

The XMLErrorResources bundle registered for #1918 only existed to produce that XPath error message, so it goes away too. 
Dropping XPath shrinks the native binary by 876 KB out of 98.7 MB.

### Checklist
- [x] [Review Contribution Guidelines](https://github.com/jreleaser/.github/blob/main/CONTRIBUTING.adoc).
- [x] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
